### PR TITLE
新增功能：為方塊放置新增保留最少物品數量在背包的功能

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,12 +21,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+<<<<<<< HEAD
+=======
+      - name: Validate gradle wrapper
+        uses: gradle/actions/wrapper-validation@v6
+
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'microsoft'
 
+<<<<<<< HEAD
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
 
@@ -39,12 +46,30 @@ jobs:
           key: ${{ runner.os }}-loom-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties', '**/*.gradle.kts', '**/gradle.properties', 'buildSrc/**') }}
           restore-keys: |
             ${{ runner.os }}-loom-
+=======
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ./.gradle
+            ./libs
+          key: ${{ runner.os }}-gradle-common-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties', '**/*.gradle.kts', '**/gradle.properties', 'buildSrc/**') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-common-
+            ${{ runner.os }}-gradle-
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
       - name: Make gradle wrapper executable
         run: chmod +x ./gradlew
 
       - name: Build fabricWrapper subproject
+<<<<<<< HEAD
         run: ./gradlew :fabricWrapper:build --stacktrace --console=plain
+=======
+        run: ./gradlew :fabricWrapper:build --stacktrace
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
       - name: Delete wrapper sources jar
         run: |

--- a/build.fabric.gradle.kts
+++ b/build.fabric.gradle.kts
@@ -19,7 +19,10 @@ version = artifactVersion
 group = modMavenGroup
 
 repositories {
+<<<<<<< HEAD
     mavenCentral()
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     fun strictMaven(url: String, vararg groups: String) = exclusiveContent {
         forRepository { maven(url) }
         filter {
@@ -29,9 +32,16 @@ repositories {
             }
         }
     }
+<<<<<<< HEAD
     strictMaven("https://maven.fabricmc.net")
     strictMaven("https://maven.fallenbreath.me/releases")
     strictMaven("https://masa.dy.fi/maven/sakura-ryoko", "fi.dy.masa")
+=======
+    strictMaven("https://mvnrepository.com/artifact/com.belerweb/pinyin4j")
+
+    strictMaven("https://maven.fabricmc.net")
+    strictMaven("https://maven.fallenbreath.me/releases")
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
     strictMaven("https://www.cursemaven.com", "curse.maven")
     strictMaven("https://api.modrinth.com/maven", "maven.modrinth")
@@ -41,6 +51,7 @@ repositories {
     strictMaven("https://jitpack.io")
 }
 
+<<<<<<< HEAD
 fun masaDependency(mod: String): String {
     val artifact = propStrOrNull("${mod}_artifact")?.takeIf { it.isNotBlank() }
     return artifact?.let { "fi.dy.masa.$mod:$it:${prop(mod)}" }
@@ -80,6 +91,16 @@ configurations.all {
         force(litematicaDependency)
         force(tweakerooDependency)
         force(modMenuDependency)
+=======
+// https://github.com/FabricMC/fabric-loader/issues/783
+configurations.all {
+    resolutionStrategy {
+        force("net.fabricmc:fabric-loader:$fabricLoaderVersion")
+        force(modrinthDependency("malilib", malilib))
+        force(modrinthDependency("litematica", litematica))
+        force(modrinthDependency("tweakeroo", propStr("tweakeroo")))
+        force(modrinthDependency("modmenu", propStr("modmenu")))
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 }
 
@@ -91,6 +112,7 @@ dependencies {
 
     implementation("com.belerweb:pinyin4j:${prop("pinyin_version")}")?.let { include(it) }
 
+<<<<<<< HEAD
     implementation(modMenuDependency)
 
     // masa
@@ -101,6 +123,14 @@ dependencies {
         exclude(group = "maven.modrinth", module = "malilib")
         exclude(group = "fi.dy.masa.malilib")
     }
+=======
+    implementation(modrinthDependency("modmenu", propStr("modmenu")))
+
+    // masa
+    implementation(modrinthDependency("malilib", malilib))
+    implementation(modrinthDependency("litematica", litematica))
+    implementation(modrinthDependency("tweakeroo", propStr("tweakeroo")))
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
     // 快捷潜影盒
     val quickshulkerUrl = prop("quickshulker").toString()

--- a/build.fabric.remap.gradle.kts
+++ b/build.fabric.remap.gradle.kts
@@ -15,7 +15,10 @@ version = artifactVersion
 group = modMavenGroup
 
 repositories {
+<<<<<<< HEAD
     mavenCentral()
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     fun strictMaven(url: String, vararg groups: String) = exclusiveContent {
         forRepository { maven(url) }
         filter {
@@ -25,9 +28,16 @@ repositories {
             }
         }
     }
+<<<<<<< HEAD
     strictMaven("https://maven.fabricmc.net")
     strictMaven("https://maven.fallenbreath.me/releases")
     strictMaven("https://masa.dy.fi/maven/sakura-ryoko", "fi.dy.masa")
+=======
+    strictMaven("https://mvnrepository.com/artifact/com.belerweb/pinyin4j")
+
+    strictMaven("https://maven.fabricmc.net")
+    strictMaven("https://maven.fallenbreath.me/releases")
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     strictMaven("https://www.cursemaven.com", "curse.maven")
     strictMaven("https://api.modrinth.com/maven", "maven.modrinth")
 
@@ -43,6 +53,7 @@ repositories {
     strictMaven("https://jitpack.io")
 }
 
+<<<<<<< HEAD
 fun masaDependency(mod: String): String {
     val artifact = propStrOrNull("${mod}_artifact")?.takeIf { it.isNotBlank() }
     return artifact?.let { "fi.dy.masa.$mod:$it:${prop(mod)}" }
@@ -82,6 +93,16 @@ configurations.all {
         force(litematicaDependency)
         force(tweakerooDependency)
         force(modMenuDependency)
+=======
+// https://github.com/FabricMC/fabric-loader/issues/783
+configurations.all {
+    resolutionStrategy {
+        force("net.fabricmc:fabric-loader:$fabricLoaderVersion")
+        force(modrinthDependency("malilib", malilib))
+        force(modrinthDependency("litematica", litematica))
+        force(modrinthDependency("tweakeroo", propStr("tweakeroo")))
+        force(modrinthDependency("modmenu", propStr("modmenu")))
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 }
 
@@ -92,6 +113,7 @@ dependencies {
     modImplementation("net.fabricmc.fabric-api:fabric-api:$fabricApiVersion")
     modImplementation("com.belerweb:pinyin4j:${prop("pinyin_version")}")?.let { include(it) }
 
+<<<<<<< HEAD
     modImplementation(modMenuDependency)
 
     modImplementation(malilibDependency)
@@ -101,6 +123,17 @@ dependencies {
         exclude(group = "maven.modrinth", module = "malilib")
         exclude(group = "fi.dy.masa.malilib")
     }
+=======
+    modImplementation(modrinthDependency("modmenu", propStr("modmenu")))
+
+    // modImplementation("com.github.sakura-ryoko:malilib:${props["malilib"]}")
+    // modImplementation("com.github.sakura-ryoko:litematica:${props["litematica"]}")
+    // modImplementation("com.github.sakura-ryoko:tweakeroo:${props["tweakeroo"]}")
+
+    modImplementation(modrinthDependency("malilib", malilib))
+    modImplementation(modrinthDependency("litematica", litematica))
+    modImplementation(modrinthDependency("tweakeroo", propStr("tweakeroo")))
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
     // 快捷潜影盒
     if (mcVersionInt >= 12006) {
@@ -112,19 +145,27 @@ dependencies {
             }
         }
         if (mcVersionInt == 12006) {  // 1.20.6 是 Haocen2004/quickshulker 分支, 所以还是使用之前老版本的依赖
+<<<<<<< HEAD
             modImplementation("net.kyrptonaught:kyrptconfig:${prop("kyrptconfig")}") {
                 exclude(group = "com.terraformersmc", module = "modmenu")
                 exclude(group = "maven.modrinth", module = "modmenu")
             }
+=======
+            modImplementation("net.kyrptonaught:kyrptconfig:${prop("kyrptconfig")}")
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         } else {
             modImplementation("me.fallenbreath:conditional-mixin-fabric:0.6.4")
         }
     } else {
         modImplementation("curse.maven:quick-shulker-362669:${prop("quick_shulker")}")
+<<<<<<< HEAD
         modImplementation("net.kyrptonaught:kyrptconfig:${prop("kyrptconfig")}") {
             exclude(group = "com.terraformersmc", module = "modmenu")
             exclude(group = "maven.modrinth", module = "modmenu")
         }
+=======
+        modImplementation("net.kyrptonaught:kyrptconfig:${prop("kyrptconfig")}")
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,12 @@
 plugins {
     id("maven-publish")
+<<<<<<< HEAD
     id("net.fabricmc.fabric-loom") version "1.16.3" apply false
     id("net.fabricmc.fabric-loom-remap") version "1.16.3" apply false
+=======
+    id("net.fabricmc.fabric-loom") version "1.15-SNAPSHOT" apply false
+    id("net.fabricmc.fabric-loom-remap") version "1.15-SNAPSHOT" apply false
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
     // https://github.com/ReplayMod/preprocessor
     // https://github.com/Fallen-Breath/preprocessor
@@ -38,6 +43,10 @@ preprocess {
     mc12103.link(mc12104, null)
     mc12104.link(mc12105, file("versions/mapping-1.21.4-1.21.5.txt"))
     mc12105.link(mc12106, null)
+<<<<<<< HEAD
+=======
+    mc12105.link(mc12106, null)
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     mc12106.link(mc12109, null)
     mc12109.link(mc12111, file("versions/mapping-1.21.10-1.21.11.txt"))
     mc12111.link(mc260100, file("versions/mapping-1.21.11-26.1.txt"))

--- a/buildSrc/src/main/kotlin/ModProjectExtension.kt
+++ b/buildSrc/src/main/kotlin/ModProjectExtension.kt
@@ -25,6 +25,26 @@ val Project.modVersion get() = propStr("mod_version")
 val Project.modMavenGroup get() = propStr("mod_maven_group")
 val Project.modArchivesBaseName get() = propStr("mod_archives_base_name")
 
+<<<<<<< HEAD
+=======
+// Some Modrinth Maven coordinates are published under internal artifact IDs
+// instead of the mod slug. This helper keeps module properties using the
+// human-readable slug+version form while translating to the real Maven artifact.
+private val modrinthArtifactIds = mapOf(
+    "litematica" to "bEpr0Arc",
+    "malilib" to "GcWjdA9I",
+    "tweakeroo" to "t5wuYk45",
+    "modmenu" to "mOgUt4GM"
+)
+
+fun Project.modrinthArtifactId(slug: String): String = modrinthArtifactIds[slug] ?: slug
+
+fun Project.modrinthDependency(slug: String, version: String?): String {
+    val artifactVersion = version ?: throw GradleException("Missing Modrinth dependency version for '$slug'")
+    return "maven.modrinth:${modrinthArtifactId(slug)}:$artifactVersion"
+}
+
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 val Project.modDescription get() = propStrOrNull("mod_description")
 val Project.modHomepage get() = propStrOrNull("mod_homepage")
 val Project.modLicense get() = propStrOrNull("mod_license")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,9 @@
 org.gradle.jvmargs=-Xmx6G
 org.gradle.java.installations.auto-detect=true
+<<<<<<< HEAD
 org.gradle.caching=true
+=======
+>>>>>>> 833a7537 (chore: Update version to distinguish fork branch)
 
 mod_archives_base_name=litematica-printer
 mod_description=Litematica Printer mulit version pack
@@ -11,7 +14,11 @@ mod_license=AGPL-3.0
 mod_maven_group=com.blinkwhite.litematica-printer
 mod_name=Litematica Printer
 mod_sources=https://github.com/Yur1Ca/litematica-printer
+<<<<<<< HEAD
 mod_version=0.7.2.1-Hana
+=======
+mod_version=0.7.2.2-Add-Inventory-Reserve
+>>>>>>> 833a7537 (chore: Update version to distinguish fork branch)
 
 loader_version=0.19.1
 pinyin_version=2.5.1

--- a/src/main/java/me/aleksilassila/litematica/printer/I18n.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/I18n.java
@@ -38,6 +38,10 @@ public class I18n {
     public static final I18n INVENTORY_FULL = of("message.inventory.full");
     public static final I18n INVENTORY_RESTORE_FAILED = of("message.inventory.restore_failed");
     public static final I18n INVENTORY_SHULKER_OCCUPIED = of("message.inventory.shulker_occupied");
+<<<<<<< HEAD
+=======
+    public static final I18n RESERVE_ITEM_SKIP = of("message.reserve_item.skip");
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
 
     private static final String PREFIX_CONFIG = "config";
     private static final String PREFIX_COMMENT = "desc";

--- a/src/main/java/me/aleksilassila/litematica/printer/config/Configs.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/config/Configs.java
@@ -250,6 +250,15 @@ public class Configs extends ConfigBuilders implements IConfigHandler {
                 .range(0, 64)
                 .build();
 
+<<<<<<< HEAD
+=======
+        // 放置保留物品数量
+        public static final ConfigInteger PLACE_RESERVE_COUNT = integer("placeReserveCount")
+                .defaultValue(0)
+                .range(0, 64)
+                .build();
+
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
         // RTT 自适应重放间隔 - 开关
         // 根据玩家 ping 自动把放置间隔抬到不低于一次往返,减少服务器下「发包快于服务端确认」导致的放错。
         public static final ConfigBoolean RTT_ADAPTIVE_INTERVAL = bool("placeRttAdaptiveInterval")
@@ -293,6 +302,10 @@ public class Configs extends ConfigBuilders implements IConfigHandler {
                 PLACE_INTERVAL,
                 PLACE_BLOCKS_PER_TICK,
                 PLACE_COOLDOWN,
+<<<<<<< HEAD
+=======
+                PLACE_RESERVE_COUNT,
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
                 RTT_ADAPTIVE_INTERVAL,
                 RTT_SAFETY_PERCENT,
                 FALLING_CHECK,
@@ -358,8 +371,11 @@ public class Configs extends ConfigBuilders implements IConfigHandler {
                 .build();
 
         public static final ImmutableList<IConfigBase> OPTIONS = ImmutableList.of(
+<<<<<<< HEAD
                 BREAK_INTERVAL,
                 BREAK_BLOCKS_PER_TICK,
+=======
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
                 BREAK_CHECK_HARDNESS,
                 BREAK_AUTO_TOOL,
                 BREAK_USE_DELAYED_DESTROY,
@@ -681,7 +697,11 @@ public class Configs extends ConfigBuilders implements IConfigHandler {
     public void load() {
         File settingFile = new File(FILE_PATH);
         if (settingFile.isFile() && settingFile.exists()) {
+<<<<<<< HEAD
             //#if MC >= 12111
+=======
+            //#if MC >= 260100
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
             JsonElement jsonElement = JsonUtils.parseJsonFile(settingFile.toPath());
             //#else
             //$$ JsonElement jsonElement = JsonUtils.parseJsonFile(settingFile);
@@ -699,7 +719,11 @@ public class Configs extends ConfigBuilders implements IConfigHandler {
         if ((CONFIG_DIR.exists() && CONFIG_DIR.isDirectory()) || CONFIG_DIR.mkdirs()) {
             JsonObject configRoot = new JsonObject();
             ConfigUtils.writeConfigBase(configRoot, Reference.MOD_ID, OPTIONS);
+<<<<<<< HEAD
             //#if MC >= 12111
+=======
+            //#if MC >= 260100
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
             JsonUtils.writeJsonToFile(configRoot, settingFile.toPath());
             //#else
             //$$ JsonUtils.writeJsonToFile(configRoot, settingFile);

--- a/src/main/java/me/aleksilassila/litematica/printer/guide/DefaultGuide.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/guide/DefaultGuide.java
@@ -127,6 +127,7 @@ public class DefaultGuide extends Guide {
         }
         return Result.PASS;
     }
+<<<<<<< HEAD
 
     @Override
     protected Result onBuildActionWrongState(BlockMatchResult state) {
@@ -137,4 +138,6 @@ public class DefaultGuide extends Guide {
         }
         return Result.PASS;
     }
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 }

--- a/src/main/java/me/aleksilassila/litematica/printer/guide/Guide.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/guide/Guide.java
@@ -59,7 +59,13 @@ public abstract class Guide extends BlockStateUtils {
 
         // 水生植物（海草等）需要水环境才能放置
         if (BlockStateUtils.requiresWaterToPlace(requiredBlock)) {
+<<<<<<< HEAD
             if (!BlockStateUtils.hasSourceWaterFluid(level.getBlockState(blockPos))) {
+=======
+            BlockPos waterPos = requiredState.hasProperty(BlockStateProperties.WATERLOGGED)
+                    ? blockPos : blockPos.above();
+            if (!BlockStateUtils.hasSourceWaterFluid(level.getBlockState(waterPos))) {
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
                 return Result.PASS;
             }
         }

--- a/src/main/java/me/aleksilassila/litematica/printer/guide/Guides.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/guide/Guides.java
@@ -1,6 +1,9 @@
 package me.aleksilassila.litematica.printer.guide;
 
+<<<<<<< HEAD
 import me.aleksilassila.litematica.printer.Reference;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 import me.aleksilassila.litematica.printer.enums.BlockMatchResult;
 import me.aleksilassila.litematica.printer.guide.guides.*;
 import me.aleksilassila.litematica.printer.printer.SchematicBlockContext;
@@ -227,6 +230,7 @@ public class Guides {
         registrations.add(new GuideRegistration(guideClass, supportedBlocks));
     }
 
+<<<<<<< HEAD
     public final Optional<Action> buildAction(SchematicBlockContext context) {
         BlockMatchResult blockMatchResult = BlockMatchResult.compare(context);
         for (GuideRegistration registration : this.registrations) {
@@ -243,6 +247,39 @@ public class Guides {
             if (!guide.canExecute()) {
                 continue;
             }
+=======
+    @SuppressWarnings("CallToPrintStackTrace")
+    private List<Guide> getGuides(SchematicBlockContext context) {
+        List<Guide> guides = new ArrayList<>();
+        for (GuideRegistration reg : registrations) {
+            boolean matches = reg.blockClass.length == 0;
+            if (!matches) {
+                for (Class<? extends Block> clazz : reg.blockClass) {
+                    if (clazz.isInstance(context.requiredState.getBlock())) {
+                        matches = true;
+                        break;
+                    }
+                }
+            }
+            if (matches) {
+                try {
+                    Guide guide = reg.create(context);
+                    if (guide.canExecute()) {
+                        guides.add(guide);
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        return guides;
+    }
+
+    public final Optional<Action> buildAction(SchematicBlockContext context) {
+        BlockMatchResult blockMatchResult = BlockMatchResult.compare(context);
+        List<Guide> guides = this.getGuides(context);
+        for (Guide guide : guides) {
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             Result result = guide.buildAction(blockMatchResult);
             if (result.hasAction()) {
                 return result.toOptional();
@@ -272,6 +309,7 @@ public class Guides {
         public Guide create(SchematicBlockContext context) throws ReflectiveOperationException {
             return this.constructor.newInstance(context);
         }
+<<<<<<< HEAD
 
         public boolean matches(Block block) {
             if (this.blockClass.length == 0) {
@@ -288,5 +326,7 @@ public class Guides {
         public String guideName() {
             return this.constructor.getDeclaringClass().getName();
         }
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 }

--- a/src/main/java/me/aleksilassila/litematica/printer/guide/guides/CauldronGuide.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/guide/guides/CauldronGuide.java
@@ -9,8 +9,11 @@ import me.aleksilassila.litematica.printer.printer.action.ClickAction;
 import me.aleksilassila.litematica.printer.utils.InteractionUtils;
 import me.aleksilassila.litematica.printer.utils.InventoryUtils;
 import net.minecraft.world.level.block.LayeredCauldronBlock;
+<<<<<<< HEAD
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.item.ItemStack;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 import net.minecraft.world.item.Items;
 
 import java.util.Optional;
@@ -26,9 +29,12 @@ public class CauldronGuide extends Guide {
 
     @Override
     protected Result onBuildActionWrongState(BlockMatchResult state) {
+<<<<<<< HEAD
         if (!requiredState.is(Blocks.WATER_CAULDRON)) {
             return Result.SKIP;
         }
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         Optional<Integer> currentLevel = getProperty(currentState, LayeredCauldronBlock.LEVEL);
         Optional<Integer> requiredLevel = getProperty(requiredState, LayeredCauldronBlock.LEVEL);
 
@@ -42,13 +48,20 @@ public class CauldronGuide extends Guide {
             }
         }
         if (currentLevel.get() < requiredLevel.get()) {
+<<<<<<< HEAD
             return this.buildWaterFillAction(requiredLevel.get());
+=======
+            if (InventoryUtils.playerHasAccessToItem(client.player, Items.POTION)) {
+                return Result.success(new ClickAction().setItem(Items.POTION));
+            }
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         }
         return Result.SKIP;
     }
 
     @Override
     protected Result onBuildActionWrongBlock(BlockMatchResult state) {
+<<<<<<< HEAD
         if (requiredState.is(Blocks.WATER_CAULDRON) && currentState.is(Blocks.CAULDRON)) {
             int requiredLevel = getProperty(requiredState, LayeredCauldronBlock.LEVEL).orElse(1);
             return this.buildWaterFillAction(requiredLevel);
@@ -58,12 +71,15 @@ public class CauldronGuide extends Guide {
                 && InventoryUtils.playerHasAccessToItem(client.player, Items.GLASS_BOTTLE)) {
             return Result.success(new ClickAction().setItem(Items.GLASS_BOTTLE));
         }
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         if (Configs.Print.BREAK_WRONG_BLOCK.getBooleanValue()
                 && InteractionUtils.canBreakBlock(blockPos)) {
             InteractionUtils.INSTANCE.add(context);
         }
         return Result.SKIP;
     }
+<<<<<<< HEAD
 
     private Result buildWaterFillAction(int requiredLevel) {
         if (requiredLevel == LayeredCauldronBlock.MAX_FILL_LEVEL
@@ -86,4 +102,6 @@ public class CauldronGuide extends Guide {
         }
         return Result.SKIP;
     }
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 }

--- a/src/main/java/me/aleksilassila/litematica/printer/guide/guides/CropsGuide.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/guide/guides/CropsGuide.java
@@ -87,6 +87,7 @@ public class CropsGuide extends Guide {
     protected Result onBuildActionWrongBlock(BlockMatchResult state) {
         String requiredKey = BlockUtils.getKeyString(requiredBlock);
         String currentKey = BlockUtils.getKeyString(currentBlock);
+<<<<<<< HEAD
         boolean wrongStem = requiredKey.contains("pumpkin_stem") && !currentKey.contains("pumpkin_stem")
                 || requiredKey.contains("melon_stem") && !currentKey.contains("melon_stem");
         if (wrongStem
@@ -97,5 +98,13 @@ public class CropsGuide extends Guide {
             return Result.SKIP;
         }
         return Result.PASS;
+=======
+        if (requiredKey.contains("pumpkin_stem") && !currentKey.contains("pumpkin_stem")) {
+            InteractionUtils.INSTANCE.add(context);
+        } else if (requiredKey.contains("melon_stem") && !currentKey.contains("melon_stem")) {
+            InteractionUtils.INSTANCE.add(context);
+        }
+        return Result.SKIP;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 }

--- a/src/main/java/me/aleksilassila/litematica/printer/guide/guides/LanternGuide.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/guide/guides/LanternGuide.java
@@ -20,6 +20,7 @@ public class LanternGuide extends Guide {
     @Override
     protected Result onBuildActionMissingBlock(BlockMatchResult state) {
         if (getProperty(requiredState, LanternBlock.HANGING).orElse(false)) {
+<<<<<<< HEAD
             return Result.success(new Action()
                     .setSides(Direction.UP)
                     .setLookDirection(Direction.UP)
@@ -29,5 +30,10 @@ public class LanternGuide extends Guide {
                 .setSides(Direction.DOWN)
                 .setLookDirection(Direction.DOWN)
                 .setRequiresSupport());
+=======
+            return Result.success(new Action().setLookDirection(Direction.UP));
+        }
+        return Result.success(new Action().setLookDirection(Direction.DOWN));
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 }

--- a/src/main/java/me/aleksilassila/litematica/printer/guide/guides/NetherPortalGuide.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/guide/guides/NetherPortalGuide.java
@@ -7,8 +7,11 @@ import me.aleksilassila.litematica.printer.printer.SchematicBlockContext;
 import me.aleksilassila.litematica.printer.printer.action.Action;
 import net.minecraft.world.level.portal.PortalShape;
 import net.minecraft.world.item.Items;
+<<<<<<< HEAD
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.block.NetherPortalBlock;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
 /**
  * 下界传送门
@@ -21,9 +24,13 @@ public class NetherPortalGuide extends Guide {
 
     @Override
     protected Result onBuildActionMissingBlock(BlockMatchResult state) {
+<<<<<<< HEAD
         Direction.Axis requiredAxis = getProperty(requiredState, NetherPortalBlock.AXIS)
                 .orElse(Direction.Axis.X);
         boolean canCreatePortal = PortalShape.findEmptyPortalShape(level, blockPos, requiredAxis).isPresent();
+=======
+        boolean canCreatePortal = PortalShape.findEmptyPortalShape(level, blockPos, net.minecraft.core.Direction.Axis.X).isPresent();
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         if (canCreatePortal) {
             return Result.success(new Action()
                     .setItems(Items.FLINT_AND_STEEL, Items.FIRE_CHARGE)

--- a/src/main/java/me/aleksilassila/litematica/printer/guide/guides/ObserverGuide.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/guide/guides/ObserverGuide.java
@@ -71,8 +71,15 @@ public class ObserverGuide extends Guide {
                 }
                 temp = offset;
             }
+<<<<<<< HEAD
             if (!isObserverInputChainReady(input)) {
                 return Result.SKIP;
+=======
+            if (!output.requiredState.isAir()) {
+                if (!isObserverInputChainReady(input)) {
+                    return Result.SKIP;
+                }
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             }
 
             // 侦测器隔空激活活塞检查
@@ -96,9 +103,18 @@ public class ObserverGuide extends Guide {
                 }
                 return Result.SKIP;
             } else {
+<<<<<<< HEAD
                 // 输出端为空不代表输入端已经安全。安全模式必须等侦测面链条就绪，
                 // 否则放置瞬间仍可能产生非原理图预期的更新脉冲。
                 return Result.SKIP;
+=======
+                if (isObserverInputChainReady(input)) {
+                    return Result.success(placementAction(facing));
+                }
+                if (!isObserverInputChainReady(output)) {
+                    return Result.SKIP;
+                }
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             }
         }
 

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/ClientPlayerTickManager.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/ClientPlayerTickManager.java
@@ -4,7 +4,10 @@ import com.google.common.collect.ImmutableList;
 import me.aleksilassila.litematica.printer.handler.handlers.bedrock.BedrockController;
 import me.aleksilassila.litematica.printer.handler.scan.ScanCache;
 import me.aleksilassila.litematica.printer.handler.handlers.*;
+<<<<<<< HEAD
 import me.aleksilassila.litematica.printer.mixin_extension.MultiPlayerGameModeExtension;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 import me.aleksilassila.litematica.printer.printer.ActionManager;
 import me.aleksilassila.litematica.printer.printer.RttReplayController;
 import me.aleksilassila.litematica.printer.printer.zxy.inventory.SwitchItem;
@@ -55,9 +58,12 @@ public class ClientPlayerTickManager {
 
     public static void resetRuntime(String reason) {
         ActionManager.INSTANCE.clearQueue();
+<<<<<<< HEAD
         if (mc.gameMode instanceof MultiPlayerGameModeExtension extension) {
             extension.litematica_printer$resetRuntime();
         }
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         NetworkUtils.clearScopedLookOverride();
         RttReplayController.INSTANCE.reset();
         ScanCache.INSTANCE.clear();

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/HudStatsManager.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/HudStatsManager.java
@@ -1,7 +1,10 @@
 package me.aleksilassila.litematica.printer.handler;
 
+<<<<<<< HEAD
 import me.aleksilassila.litematica.printer.config.Configs;
 import me.aleksilassila.litematica.printer.printer.RttReplayController;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.state.BlockState;
@@ -75,6 +78,7 @@ public final class HudStatsManager {
         if (mode != Mode.PRINT || pos == null || expectedState == null) {
             return;
         }
+<<<<<<< HEAD
         long now = ClientPlayerTickManager.getCurrentHandlerTime();
         this.pendingPrintStates.put(
                 pos.immutable(),
@@ -95,6 +99,14 @@ public final class HudStatsManager {
             return false;
         }
         return true;
+=======
+        Minecraft client = Minecraft.getInstance();
+        if (client.level != null && client.level.getBlockState(pos).equals(expectedState)) {
+            return;
+        }
+        long now = ClientPlayerTickManager.getCurrentHandlerTime();
+        this.pendingPrintStates.put(pos.immutable(), new PendingBlockState(expectedState, now + PRINT_CONFIRM_TIMEOUT_TICKS));
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 
     public void trackExpectedMineClear(Mode mode, BlockPos pos) {
@@ -138,8 +150,14 @@ public final class HudStatsManager {
         long now = ClientPlayerTickManager.getCurrentHandlerTime();
         BlockState currentState = client.level.getBlockState(pos);
 
+<<<<<<< HEAD
         PendingBlockState printPending = this.pendingPrintStates.remove(pos);
         if (printPending != null && currentState.equals(printPending.expectedState())) {
+=======
+        PendingBlockState printPending = this.pendingPrintStates.get(pos);
+        if (printPending != null && currentState.equals(printPending.expectedState())) {
+            this.pendingPrintStates.remove(pos);
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             this.stats.get(Mode.PRINT).recordConfirmedUnit(now, 1);
         }
 
@@ -182,7 +200,10 @@ public final class HudStatsManager {
     }
 
     private void flushConfirmedPrintPlacements(Minecraft client, long now, int maxChecks) {
+<<<<<<< HEAD
         int confirmationFloorTicks = this.getPrintConfirmationFloorTicks();
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         for (int checked = 0; checked < maxChecks && !this.pendingPrintStates.isEmpty(); checked++) {
             Iterator<Map.Entry<BlockPos, PendingBlockState>> iterator = this.pendingPrintStates.entrySet().iterator();
             Map.Entry<BlockPos, PendingBlockState> entry = iterator.next();
@@ -192,16 +213,24 @@ public final class HudStatsManager {
             if (now > pending.expireTick()) {
                 continue;
             }
+<<<<<<< HEAD
             if (now - pending.sentTick() < confirmationFloorTicks) {
                 this.pendingPrintStates.put(pos, pending);
                 continue;
             }
             if (client.level.getBlockState(pos).equals(pending.expectedState())) {
                 this.stats.get(Mode.PRINT).recordConfirmedUnit(now, 1);
+=======
+            if (client.level.getBlockState(pos).equals(pending.expectedState())) {
+                this.stats.get(Mode.PRINT).recordConfirmedUnit(now, 1);
+            } else {
+                this.pendingPrintStates.put(pos, pending);
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             }
         }
     }
 
+<<<<<<< HEAD
     private int getPrintConfirmationFloorTicks() {
         int safetyPercent = Configs.Placement.RTT_ADAPTIVE_INTERVAL.getBooleanValue()
                 ? Configs.Placement.RTT_SAFETY_PERCENT.getIntegerValue()
@@ -212,6 +241,8 @@ public final class HudStatsManager {
         );
     }
 
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     private void flushConfirmedMineClears(Minecraft client, long now, int maxChecks) {
         for (int checked = 0; checked < maxChecks && !this.pendingMineTargets.isEmpty(); checked++) {
             Iterator<Map.Entry<BlockPos, Long>> iterator = this.pendingMineTargets.entrySet().iterator();
@@ -362,7 +393,11 @@ public final class HudStatsManager {
         }
     }
 
+<<<<<<< HEAD
     private record PendingBlockState(BlockState expectedState, long sentTick, long expireTick) {
+=======
+    private record PendingBlockState(BlockState expectedState, long expireTick) {
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 
     private record PendingStateChange(BlockState originalState, long expireTick) {

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/Module.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/Module.java
@@ -71,12 +71,15 @@ public abstract class Module extends ConfigUtils {
     private PrinterBox activeDirtyScanBox;
     private boolean currentIterationDidWork;
     private boolean currentIterationFoundCandidate;
+<<<<<<< HEAD
     private int lazyProbeTicks;
     private boolean inventoryFingerprintInitialized;
     private int lastInventoryFingerprint;
     private boolean schematicIdentityInitialized;
     @Nullable
     private Object lastSchematicIdentity;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
     protected Minecraft mc;
     protected ClientLevel level;
@@ -120,11 +123,14 @@ public abstract class Module extends ConfigUtils {
         this.iterationConsumedEffectiveExecution = true;
         this.currentIterationDidWork = false;
         this.currentIterationFoundCandidate = false;
+<<<<<<< HEAD
         this.lazyProbeTicks = 0;
         this.inventoryFingerprintInitialized = false;
         this.lastInventoryFingerprint = 0;
         this.schematicIdentityInitialized = false;
         this.lastSchematicIdentity = null;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         this.lastTickTime = -1L;
         this.onRuntimeReset();
     }
@@ -149,12 +155,18 @@ public abstract class Module extends ConfigUtils {
             this.resetPlayerTracking();
             return;
         }
+<<<<<<< HEAD
         WorldSchematic schematic = SchematicWorldHandler.getSchematicWorld();
         ScanCache.INSTANCE.beginTick(this.level, schematic, context.gameTime);
         this.wakeForSchematicChange(schematic);
         this.updatePlayerInteractionBox();
         this.preprocess(); // 运行前处理的事情
         this.wakeForInventoryChange();
+=======
+        ScanCache.INSTANCE.beginTick(this.level, SchematicWorldHandler.getSchematicWorld(), context.gameTime);
+        this.updatePlayerInteractionBox();
+        this.preprocess(); // 运行前处理的事情
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         if (!this.isConfigAllowExecute()) {
             this.resetScanRuntime();
             this.resetPlayerTracking();
@@ -207,6 +219,7 @@ public abstract class Module extends ConfigUtils {
         this.interactionBoxTracker.update(this.player);
     }
 
+<<<<<<< HEAD
     private void wakeForInventoryChange() {
         int fingerprint = 1;
         for (int slot = 0; slot < this.player.getInventory().getContainerSize(); slot++) {
@@ -241,6 +254,8 @@ public abstract class Module extends ConfigUtils {
         }
     }
 
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     private boolean runIterationIfNeeded() {
         if (this.playerInteractionBox == null || !this.canExecute()) {
             this.updateExternalScanBox(null);
@@ -313,11 +328,14 @@ public abstract class Module extends ConfigUtils {
             this.refreshDirtyScanQueue(playerInteractionBox);
         }
         if (this.scanState == ScanState.LAZY) {
+<<<<<<< HEAD
             int fallbackProbeInterval = Math.max(40, Configs.Core.LAZY_ENTER_TICKS.getIntegerValue() * 10);
             if (++this.lazyProbeTicks < fallbackProbeInterval) {
                 return false;
             }
             this.lazyProbeTicks = 0;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             return this.runLazyProbeIteration(playerInteractionBox);
         }
         if (this.scanState == ScanState.FULL) {
@@ -338,7 +356,10 @@ public abstract class Module extends ConfigUtils {
         if (this.currentIterationDidWork || this.currentIterationFoundCandidate) {
             this.scanState = ScanState.FULL;
             this.idleScanTicks = 0;
+<<<<<<< HEAD
             this.lazyProbeTicks = 0;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             return interrupt;
         }
         this.scanState = ScanState.LAZY;
@@ -420,7 +441,10 @@ public abstract class Module extends ConfigUtils {
         if (++this.idleScanTicks >= lazyThreshold) {
             this.scanState = ScanState.LAZY;
             this.idleScanTicks = 0;
+<<<<<<< HEAD
             this.lazyProbeTicks = 0;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             this.clearDirtyScanQueue();
         }
     }
@@ -433,7 +457,10 @@ public abstract class Module extends ConfigUtils {
         if (!this.hasPendingPartialScan()) {
             this.scanState = ScanState.LAZY;
             this.idleScanTicks = 0;
+<<<<<<< HEAD
             this.lazyProbeTicks = 0;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             this.pendingDirtyRegionCount = 0;
         }
     }
@@ -499,14 +526,20 @@ public abstract class Module extends ConfigUtils {
     protected final void requestFullScan() {
         this.scanState = ScanState.FULL;
         this.idleScanTicks = 0;
+<<<<<<< HEAD
         this.lazyProbeTicks = 0;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         this.clearDirtyScanQueue();
     }
 
     private void resetScanRuntime() {
         this.scanState = ScanState.FULL;
         this.idleScanTicks = 0;
+<<<<<<< HEAD
         this.lazyProbeTicks = 0;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         this.lastScanSourceBox = null;
         this.lastScanSourceBoxes = List.of();
         this.updateExternalScanBox(null);

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/TickScheduler.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/TickScheduler.java
@@ -20,9 +20,12 @@ final class TickScheduler {
     private int packetTick;
     private int packetEpoch;
     private String lastPauseReason;
+<<<<<<< HEAD
     private boolean runtimeActive;
     private int executionScopeHash = Integer.MIN_VALUE;
     private int roundRobinOffset;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
     TickScheduler(ImmutableList<Module> modules) {
         this.modules = modules;
@@ -31,6 +34,7 @@ final class TickScheduler {
     void tick() {
         HudStatsManager.INSTANCE.tick();
         if (!Configs.Core.WORK_SWITCH.getBooleanValue()) {
+<<<<<<< HEAD
             if (this.runtimeActive) {
                 ClientPlayerTickManager.resetRuntime("work_switch_disabled");
             }
@@ -48,6 +52,10 @@ final class TickScheduler {
             this.runtimeActive = true;
             this.executionScopeHash = currentScopeHash;
             return;
+=======
+            HudStatsManager.INSTANCE.resetAll();
+            this.lastPauseReason = null;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         }
         if (this.pauseForInventoryState("shared_precheck")) {
             return;
@@ -62,6 +70,7 @@ final class TickScheduler {
         TickContext context = TickContext.capture();
         this.resume();
         for (Module handler : this.modules) {
+<<<<<<< HEAD
             if (handler instanceof GuiHandler) {
                 handler.tick(context);
             }
@@ -76,6 +85,12 @@ final class TickScheduler {
             Module handler = this.modules.get(1 + (startIndex + offset) % actionableCount);
             if (this.pauseForHandlerPrecheck(handler)) {
                 return;
+=======
+            if (!(handler instanceof GuiHandler)) {
+                if (this.pauseForHandlerPrecheck(handler)) {
+                    return;
+                }
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             }
             handler.tick(context);
         }
@@ -102,9 +117,12 @@ final class TickScheduler {
         this.packetTick = 0;
         this.packetEpoch++;
         this.lastPauseReason = null;
+<<<<<<< HEAD
         this.runtimeActive = false;
         this.executionScopeHash = Integer.MIN_VALUE;
         this.roundRobinOffset = 0;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 
     String getLastPauseReason() {
@@ -169,6 +187,7 @@ final class TickScheduler {
         }
         return false;
     }
+<<<<<<< HEAD
 
     private int currentExecutionScopeHash() {
         int result = Configs.Core.WORK_MODE.getOptionListValue().hashCode();
@@ -180,4 +199,6 @@ final class TickScheduler {
         result = 31 * result + Boolean.hashCode(Configs.Hotkeys.BEDROCK.getBooleanValue());
         return result;
     }
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 }

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/FillHandler.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/FillHandler.java
@@ -111,7 +111,10 @@ public class FillHandler extends Module {
         if (this.observedFillScanConfigHash != Integer.MIN_VALUE
                 && this.observedFillScanConfigHash != scanConfigHash) {
             this.clearFillTargets();
+<<<<<<< HEAD
             ScanCache.INSTANCE.resetOwner(NAME);
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             this.requestFullScan();
         }
         this.observedFillScanConfigHash = scanConfigHash;
@@ -139,6 +142,14 @@ public class FillHandler extends Module {
     }
 
     @Override
+<<<<<<< HEAD
+=======
+    protected boolean usesDirtyRegionWakeup() {
+        return false;
+    }
+
+    @Override
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     protected boolean iterationPositionsPrefilterReachAndSelection() {
         return true;
     }
@@ -311,6 +322,7 @@ public class FillHandler extends Module {
         }
         BlockPos clickTarget = Configs.Print.PLACE_IN_AIR.getBooleanValue() ? blockPos : blockPos.relative(side);
         Direction clickSide = side.getOpposite();
+<<<<<<< HEAD
         Item[] expectedItems = handheld
                 ? new Item[]{player.getMainHandItem().getItem()}
                 : this.fillModeItemList;
@@ -345,6 +357,19 @@ public class FillHandler extends Module {
         HudStatsManager.INSTANCE.trackExpectedBlockChange(HudStatsManager.Mode.FILL, blockPos, currentState);
         HudStatsManager.INSTANCE.recordRateUnit(HudStatsManager.Mode.FILL, 1);
         HudStatsManager.INSTANCE.recordStatus(HudStatsManager.Mode.FILL, "运行中");
+=======
+        ActionManager.INSTANCE.queueClick(clickTarget, clickSide, Vec3.ZERO, false);
+        ActionManager.INSTANCE.setLook(new PlayerLook(clickSide));
+        ActionManager.INSTANCE.setWaitForHorizontalLook(false);
+        HudStatsManager.INSTANCE.trackExpectedBlockChange(HudStatsManager.Mode.FILL, blockPos, currentState);
+        HudStatsManager.INSTANCE.recordRateUnit(HudStatsManager.Mode.FILL, 1);
+        if (ActionManager.INSTANCE.sendQueue(player).needWaitModifyLook) {
+            HudStatsManager.INSTANCE.recordDeferred(HudStatsManager.Mode.FILL, "等待转头");
+            skipIteration.set(true);
+        } else {
+            HudStatsManager.INSTANCE.recordStatus(HudStatsManager.Mode.FILL, "运行中");
+        }
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         this.setBlockPosCooldown(blockPos, ConfigUtils.getPlaceCooldown());
     }
 

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/FluidHandler.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/FluidHandler.java
@@ -8,17 +8,25 @@ import me.aleksilassila.litematica.printer.handler.scan.ScanCache;
 import me.aleksilassila.litematica.printer.handler.scan.ScanIntent;
 import me.aleksilassila.litematica.printer.printer.ActionManager;
 import me.aleksilassila.litematica.printer.printer.PrinterBox;
+<<<<<<< HEAD
 import me.aleksilassila.litematica.printer.printer.PrinterUtils;
 import me.aleksilassila.litematica.printer.utils.ConfigUtils;
 import me.aleksilassila.litematica.printer.utils.InventoryUtils;
 import me.aleksilassila.litematica.printer.utils.RegistryFilterResolver;
 import me.aleksilassila.litematica.printer.utils.minecraft.BlockUtils;
+=======
+import me.aleksilassila.litematica.printer.utils.InventoryUtils;
+import me.aleksilassila.litematica.printer.utils.RegistryFilterResolver;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.FluidState;
+<<<<<<< HEAD
 import net.minecraft.world.level.block.state.BlockState;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 import net.minecraft.world.phys.Vec3;
 
 import java.util.ArrayList;
@@ -29,6 +37,7 @@ import java.util.function.Predicate;
 
 public class FluidHandler extends Module {
     public final static String NAME = "fluid";
+<<<<<<< HEAD
     private static final Direction[] PLACEMENT_SIDE_ORDER = {
             Direction.DOWN,
             Direction.NORTH,
@@ -37,6 +46,8 @@ public class FluidHandler extends Module {
             Direction.WEST,
             Direction.UP
     };
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
     private List<String> fillBlocks = new ArrayList<>();
     private List<Item> fillItems = new ArrayList<>();
@@ -44,7 +55,10 @@ public class FluidHandler extends Module {
 
     private List<String> fluidBlocks = new ArrayList<>();
     private Set<Fluid> fluids = Set.of();
+<<<<<<< HEAD
     private int observedScanConfigHash = Integer.MIN_VALUE;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
     public FluidHandler() {
         super(NAME, PrintModeType.FLUID, Configs.Core.FLUID, Configs.Fluid.FLUID_SELECTION_TYPE, true);
@@ -85,6 +99,7 @@ public class FluidHandler extends Module {
         } else {
             HudStatsManager.INSTANCE.recordStatus(HudStatsManager.Mode.FLUID, "运行中");
         }
+<<<<<<< HEAD
         int scanConfigHash = this.getScanConfigHash();
         if (this.observedScanConfigHash != Integer.MIN_VALUE
                 && this.observedScanConfigHash != scanConfigHash) {
@@ -97,11 +112,17 @@ public class FluidHandler extends Module {
     @Override
     protected void onRuntimeReset() {
         this.observedScanConfigHash = Integer.MIN_VALUE;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 
     @Override
     protected boolean canIterate() {
+<<<<<<< HEAD
         return !fillItems.isEmpty() && !fluids.isEmpty();
+=======
+        return !fillItems.isEmpty() && !fluidBlocks.isEmpty();
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 
     @Override
@@ -156,6 +177,7 @@ public class FluidHandler extends Module {
             }
             return;
         }
+<<<<<<< HEAD
         BlockPos clickTarget = blockPos;
         Direction clickSide = Direction.DOWN;
         if (!Configs.Print.PLACE_IN_AIR.getBooleanValue()) {
@@ -210,6 +232,22 @@ public class FluidHandler extends Module {
             }
         }
         return null;
+=======
+        ActionManager.INSTANCE.queueClick(
+                Configs.Print.PLACE_IN_AIR.getBooleanValue() ? blockPos : blockPos.above(),
+                Direction.DOWN,
+                Vec3.ZERO,
+                false
+        );
+        HudStatsManager.INSTANCE.trackExpectedBlockChange(HudStatsManager.Mode.FLUID, blockPos, level.getBlockState(blockPos));
+        HudStatsManager.INSTANCE.recordRateUnit(HudStatsManager.Mode.FLUID, 1);
+        if (ActionManager.INSTANCE.sendQueue(player).needWaitModifyLook) {
+            HudStatsManager.INSTANCE.recordDeferred(HudStatsManager.Mode.FLUID, "等待转头");
+            skipIteration.set(true);
+        } else {
+            HudStatsManager.INSTANCE.recordStatus(HudStatsManager.Mode.FLUID, "运行中");
+        }
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 
     private boolean isTargetFluid(BlockPos blockPos) {
@@ -220,6 +258,7 @@ public class FluidHandler extends Module {
         return fluids.contains(fluidState.getType())
                 && (Configs.Fluid.FILL_FLOWING_FLUID.getBooleanValue() || fluidState.isSource());
     }
+<<<<<<< HEAD
 
     private int getScanConfigHash() {
         int result = this.fillBlocks.hashCode();
@@ -227,4 +266,6 @@ public class FluidHandler extends Module {
         result = 31 * result + Boolean.hashCode(Configs.Fluid.FILL_FLOWING_FLUID.getBooleanValue());
         return result;
     }
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 }

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/MineBreakExecutor.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/MineBreakExecutor.java
@@ -88,6 +88,12 @@ final class MineBreakExecutor {
         if (player == null || !this.shouldResolveBestTool()) {
             return true;
         }
+<<<<<<< HEAD
+=======
+        if (target.bestToolItem == player.getMainHandItem().getItem()) {
+            return true;
+        }
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         return target.currentProgress >= target.bestProgress * CURRENT_TOOL_MIN_EFFICIENCY_RATIO;
     }
 

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/MineHandler.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/MineHandler.java
@@ -89,7 +89,11 @@ public class MineHandler extends Module {
 
     @Override
     protected int getTickInterval() {
+<<<<<<< HEAD
         return Configs.Break.BREAK_INTERVAL.getIntegerValue();
+=======
+        return 0;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 
     @Override
@@ -145,6 +149,7 @@ public class MineHandler extends Module {
     }
 
     @Override
+<<<<<<< HEAD
     protected boolean iterationPositionsPrefilterReachAndSelection() {
         return true;
     }
@@ -160,6 +165,8 @@ public class MineHandler extends Module {
     }
 
     @Override
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     public boolean canIterationBlockPos(BlockPos pos) {
         return this.isMineScanCandidate(pos);
     }

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/MineToolSession.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/MineToolSession.java
@@ -1,7 +1,10 @@
 package me.aleksilassila.litematica.printer.handler.handlers;
 
 import me.aleksilassila.litematica.printer.mixin_extension.BlockBreakResult;
+<<<<<<< HEAD
 import me.aleksilassila.litematica.printer.config.Configs;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 import me.aleksilassila.litematica.printer.utils.InteractionUtils;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
@@ -29,8 +32,12 @@ final class MineToolSession {
     }
 
     void beginTick() {
+<<<<<<< HEAD
         int configuredBudget = Configs.Break.BREAK_BLOCKS_PER_TICK.getIntegerValue();
         this.remainingInstantBudget = configuredBudget <= 0 ? -1 : configuredBudget;
+=======
+        this.remainingInstantBudget = -1;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         this.remainingSafeToolBreaks = InteractionUtils.getCurrentToolSafeBreakBudget();
     }
 

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/PrintHandler.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/PrintHandler.java
@@ -5,9 +5,13 @@ import fi.dy.masa.litematica.world.WorldSchematic;
 import me.aleksilassila.litematica.printer.config.Configs;
 import me.aleksilassila.litematica.printer.enums.PrintModeType;
 import me.aleksilassila.litematica.printer.guide.Guides;
+<<<<<<< HEAD
 import me.aleksilassila.litematica.printer.handler.HudStatsManager;
 import me.aleksilassila.litematica.printer.handler.Module;
 import me.aleksilassila.litematica.printer.handler.scan.ScanCache;
+=======
+import me.aleksilassila.litematica.printer.handler.Module;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 import me.aleksilassila.litematica.printer.handler.scan.ScanIntent;
 import me.aleksilassila.litematica.printer.handler.handlers.print.PrintPlacementExecutor;
 import me.aleksilassila.litematica.printer.handler.handlers.print.PrintPlacementResult;
@@ -41,7 +45,10 @@ public class PrintHandler extends Module {
 
     private List<String> printSkipListCache = List.of();
     private String[] printSkipFilters = new String[0];
+<<<<<<< HEAD
     private int observedActionConfigHash = Integer.MIN_VALUE;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
     public PrintHandler() {
         super(NAME, PrintModeType.PRINTER, Configs.Core.PRINT, Configs.Print.PRINT_SELECTION_TYPE, true);
@@ -79,6 +86,7 @@ public class PrintHandler extends Module {
     @Override
     protected void preprocess() {
         this.updatePrintSkipCache();
+<<<<<<< HEAD
         int actionConfigHash = this.getActionConfigHash();
         if (this.observedActionConfigHash != Integer.MIN_VALUE
                 && this.observedActionConfigHash != actionConfigHash) {
@@ -88,6 +96,8 @@ public class PrintHandler extends Module {
             this.requestFullScan();
         }
         this.observedActionConfigHash = actionConfigHash;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 
     @Override
@@ -97,7 +107,10 @@ public class PrintHandler extends Module {
         this.ctx = null;
         this.printTasks.clear();
         this.sortedTargets.clear();
+<<<<<<< HEAD
         this.observedActionConfigHash = Integer.MIN_VALUE;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 
     @Override
@@ -130,9 +143,12 @@ public class PrintHandler extends Module {
         this.printTaskAction = null;
         WorldSchematic schematic = SchematicWorldHandler.getSchematicWorld();
         if (schematic == null) return false;
+<<<<<<< HEAD
         if (HudStatsManager.INSTANCE.isPrintPlacementPending(blockPos)) {
             return false;
         }
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         if (InteractionUtils.INSTANCE.isRecentlyBroken(blockPos) && !this.printTasks.isActiveTaskPos(blockPos)) {
             return false;
         }
@@ -167,6 +183,7 @@ public class PrintHandler extends Module {
         this.printSkipFilters = this.printSkipListCache.toArray(new String[0]);
     }
 
+<<<<<<< HEAD
     private int getActionConfigHash() {
         int result = Boolean.hashCode(Configs.Print.BREAK_WRONG_BLOCK.getBooleanValue());
         result = 31 * result + Boolean.hashCode(Configs.Print.BREAK_EXTRA_BLOCK.getBooleanValue());
@@ -188,6 +205,8 @@ public class PrintHandler extends Module {
         return result;
     }
 
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     private boolean shouldSkipRequiredState(BlockState requiredState) {
         if (!Configs.Print.PRINT_SKIP.getBooleanValue() || this.printSkipFilters.length == 0) {
             return false;
@@ -222,7 +241,10 @@ public class PrintHandler extends Module {
         switch (taskEvent) {
             case SUCCESS -> this.printTasks.onActionSuccess(taskAction, this.ctx, this.action);
             case QUEUED -> this.printTasks.onActionQueued(taskAction, this.ctx, this.action);
+<<<<<<< HEAD
             case CANCELLED -> taskAction.onCancelled(this.ctx, this.action);
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             case FAILURE -> this.printTasks.onActionFailure(taskAction, this.ctx, this.action);
         }
     }

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/bedrock/BedrockBreaker.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/bedrock/BedrockBreaker.java
@@ -1,11 +1,20 @@
 package me.aleksilassila.litematica.printer.handler.handlers.bedrock;
 
 import me.aleksilassila.litematica.printer.mixin_extension.MultiPlayerGameModeExtension;
+<<<<<<< HEAD
 import me.aleksilassila.litematica.printer.mixin_extension.BlockBreakResult;
 import me.aleksilassila.litematica.printer.utils.InteractionUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+=======
+import me.aleksilassila.litematica.printer.utils.InteractionUtils;
+import me.aleksilassila.litematica.printer.utils.minecraft.NetworkUtils;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.network.protocol.game.ServerboundPlayerActionPacket;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
 public final class BedrockBreaker {
     private static final Minecraft CLIENT = Minecraft.getInstance();
@@ -41,6 +50,7 @@ public final class BedrockBreaker {
             return false;
         }
 
+<<<<<<< HEAD
         if (CLIENT.gameMode instanceof MultiPlayerGameModeExtension gameModeExtension) {
             BlockBreakResult result = gameModeExtension.litematica_printer$continueDestroyBlock(
                     false,
@@ -51,6 +61,47 @@ public final class BedrockBreaker {
             );
             return result != BlockBreakResult.FAILED && result != BlockBreakResult.ABORTED;
         }
+=======
+        if (CLIENT.gameMode instanceof MultiPlayerGameModeExtension gameModeExtension && !shouldPredictRemoval()) {
+            gameModeExtension.litematica_printer$continueDestroyBlock(false, pos, direction);
+        }
+
+        //#if MC >= 11900
+        NetworkUtils.sendPacket(sequence -> new ServerboundPlayerActionPacket(
+                ServerboundPlayerActionPacket.Action.START_DESTROY_BLOCK,
+                pos,
+                direction,
+                sequence
+        ));
+        NetworkUtils.sendPacket(sequence -> new ServerboundPlayerActionPacket(
+                ServerboundPlayerActionPacket.Action.STOP_DESTROY_BLOCK,
+                pos,
+                direction,
+                sequence
+        ));
+        //#else
+        //$$ NetworkUtils.sendPacket(new ServerboundPlayerActionPacket(
+        //$$         ServerboundPlayerActionPacket.Action.START_DESTROY_BLOCK,
+        //$$         pos,
+        //$$         Direction.DOWN
+        //$$ ));
+        //$$ NetworkUtils.sendPacket(new ServerboundPlayerActionPacket(
+        //$$         ServerboundPlayerActionPacket.Action.STOP_DESTROY_BLOCK,
+        //$$         pos,
+        //$$         Direction.DOWN
+        //$$ ));
+        //#endif
+
+        boolean allowPrediction = predictRemoval && shouldPredictRemoval();
+        if (allowPrediction) {
+            CLIENT.level.removeBlock(pos, false);
+        }
+
+        return true;
+    }
+
+    private static boolean shouldPredictRemoval() {
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         return false;
     }
 }

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/bedrock/BedrockController.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/bedrock/BedrockController.java
@@ -1002,7 +1002,11 @@ public final class BedrockController {
         }
         if (CLIENT.level != null && BedrockMachineLayout.shouldDeferUntilExposed(CLIENT.level, stablePos)) {
             int defers = EXPOSURE_DEFERRALS.getOrDefault(stablePos, 0) + 1;
+<<<<<<< HEAD
             if (defers <= MAX_VERTICAL_EXPOSURE_DEFERS) {
+=======
+            if (defers < MAX_VERTICAL_EXPOSURE_DEFERS) {
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
                 if (mutateExposureState) {
                     EXPOSURE_DEFERRALS.put(stablePos, defers);
                 }

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/bedrock/BedrockTarget.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/bedrock/BedrockTarget.java
@@ -17,7 +17,10 @@ public class BedrockTarget {
     private static final int POWERED_STALL_RECOVERY_TICKS = 2;
     private static final int POST_EXECUTE_SYNC_TIMEOUT_TICKS = 16;
     private static final int INITIALIZE_SYNC_GRACE_TICKS = 2;
+<<<<<<< HEAD
     private static final int INITIALIZE_SYNC_TIMEOUT_TICKS = 40;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     private static final int POST_EXECUTE_AIR_SETTLE_TICKS = 4;
     private static final int POST_EXECUTE_RESIDUE_CLEANUP_INTERVAL_TICKS = 4;
     private static final int POLLUTED_MACHINE_CLEANUP_INTERVAL_TICKS = 4;
@@ -153,13 +156,21 @@ public class BedrockTarget {
                 if (!BedrockPlacer.placePiston(this.pistonPos, this.layout.getPrimingFacing())) {
                     break;
                 }
+<<<<<<< HEAD
                 this.initializeTick = this.tickTimes;
                 markThroughputAction();
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
                 if (this.torchSupportPos != null && !hasOwnedTorchPowerSource()) {
                     if (!placeTorch()) {
                         break;
                     }
                 }
+<<<<<<< HEAD
+=======
+                this.initializeTick = this.tickTimes;
+                markThroughputAction();
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             }
             case EXTENDED -> {
                 if (!allowExecute) {
@@ -632,12 +643,15 @@ public class BedrockTarget {
             this.status = Status.NEEDS_WAITING;
             return;
         }
+<<<<<<< HEAD
         if (!this.hasTried
                 && this.initializeTick >= 0
                 && this.tickTimes - this.initializeTick <= INITIALIZE_SYNC_TIMEOUT_TICKS) {
             this.status = Status.NEEDS_WAITING;
             return;
         }
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         if (!this.hasTried && hasAnyTransientMachineResidue()) {
             this.status = Status.NEEDS_WAITING;
             return;

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/print/PrintPlacementExecutor.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/print/PrintPlacementExecutor.java
@@ -3,7 +3,10 @@ package me.aleksilassila.litematica.printer.handler.handlers.print;
 import me.aleksilassila.litematica.printer.I18n;
 import me.aleksilassila.litematica.printer.config.Configs;
 import me.aleksilassila.litematica.printer.handler.HudStatsManager;
+<<<<<<< HEAD
 import me.aleksilassila.litematica.printer.handler.handlers.PrintHandler;
+=======
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
 import me.aleksilassila.litematica.printer.interfaces.Implementation;
 import me.aleksilassila.litematica.printer.printer.ActionManager;
 import me.aleksilassila.litematica.printer.printer.PlayerLook;
@@ -11,10 +14,17 @@ import me.aleksilassila.litematica.printer.printer.SchematicBlockContext;
 import me.aleksilassila.litematica.printer.printer.action.Action;
 import me.aleksilassila.litematica.printer.printer.action.ClickAction;
 import me.aleksilassila.litematica.printer.utils.ConfigUtils;
+<<<<<<< HEAD
 import me.aleksilassila.litematica.printer.utils.CooldownUtils;
 import me.aleksilassila.litematica.printer.utils.InventoryUtils;
 import me.aleksilassila.litematica.printer.utils.minecraft.DirectionUtils;
 import me.aleksilassila.litematica.printer.utils.minecraft.MessageUtils;
+=======
+import me.aleksilassila.litematica.printer.utils.InventoryUtils;
+import me.aleksilassila.litematica.printer.utils.minecraft.DirectionUtils;
+import me.aleksilassila.litematica.printer.utils.minecraft.MessageUtils;
+import me.aleksilassila.litematica.printer.utils.minecraft.PlayerUtils;
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
 import me.aleksilassila.litematica.printer.utils.mods.LitematicaUtils;
 import me.aleksilassila.litematica.printer.utils.mods.TakeItOutUtils;
 import net.minecraft.core.BlockPos;
@@ -25,10 +35,13 @@ import net.minecraft.world.level.block.FallingBlock;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
 
+<<<<<<< HEAD
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 import net.minecraft.world.item.ItemStack;
 
+=======
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
 public final class PrintPlacementExecutor {
     private static final Item[] EMPTY_HAND_ITEMS = {Items.AIR};
 
@@ -50,6 +63,7 @@ public final class PrintPlacementExecutor {
         }
 
         Item[] requiredItems = normalizeRequiredItems(action.getRequiredItems(context.requiredState.getBlock()));
+<<<<<<< HEAD
         Predicate<ItemStack> requiredStackPredicate = action.getRequiredStackPredicate();
         boolean itemReady = requiredStackPredicate == null
                 ? InventoryUtils.switchToItems(context.client.player, requiredItems)
@@ -61,30 +75,58 @@ public final class PrintPlacementExecutor {
         if (!itemReady) {
             HudStatsManager.INSTANCE.recordDeferred(HudStatsManager.Mode.PRINT, "缺少材料");
             // 缺少材料属于无效放置，不应消耗每 tick 的有效放置预算（与重构前行为一致）。
+=======
+        int reserveCount = Configs.Placement.PLACE_RESERVE_COUNT.getIntegerValue();
+        if (!InventoryUtils.hasEnoughItemsForReserve(context.client.player, requiredItems, reserveCount)) {
+            HudStatsManager.INSTANCE.recordDeferred(HudStatsManager.Mode.PRINT, "缺少材料");
+            if (reserveCount > 0) {
+                String cooldownKey = "reserve_item_skip_" + context.requiredBlockName().getString();
+                InventoryUtils.setOverlayMessageWithCooldown(
+                    I18n.RESERVE_ITEM_SKIP.getName(reserveCount, context.requiredBlockName().getString()),
+                    cooldownKey
+                );
+            }
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
             return PrintPlacementResult.failure(false,
                     shouldStopAfterTaskAction(taskAction)
                             || me.aleksilassila.litematica.printer.printer.zxy.inventory.InventoryUtils.shouldPauseForSwitchRequest()
                             || TakeItOutUtils.isAwaitingStack());
         }
+<<<<<<< HEAD
         if (!InventoryUtils.isHoldingAnyItem(context.client.player, requiredItems)
                 || requiredStackPredicate != null
                 && !requiredStackPredicate.test(context.client.player.getMainHandItem())) {
+=======
+        if (!InventoryUtils.switchToItemsWithReserve(context.client.player, requiredItems, reserveCount)) {
+            HudStatsManager.INSTANCE.recordDeferred(HudStatsManager.Mode.PRINT, "缺少材料");
+            return PrintPlacementResult.failure(false,
+                    shouldStopAfterTaskAction(taskAction)
+                            || me.aleksilassila.litematica.printer.printer.zxy.inventory.InventoryUtils.shouldPauseForSwitchRequest()
+                            || TakeItOutUtils.isAwaitingStack());
+        }
+        if (!InventoryUtils.isHoldingAnyItem(context.client.player, requiredItems)) {
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
             HudStatsManager.INSTANCE.recordDeferred(HudStatsManager.Mode.PRINT, "等待物品同步");
             return PrintPlacementResult.failure(false, true);
         }
 
         boolean useShift = getUseShift(context, action, side);
+<<<<<<< HEAD
         if (!action.queueAction(blockPos, side, useShift, context.client.player, requiredItems)) {
             HudStatsManager.INSTANCE.recordDeferred(HudStatsManager.Mode.PRINT, "动作队列占用");
             return PrintPlacementResult.cancelled(true);
         }
         ActionManager.INSTANCE.setExpectedStackPredicate(requiredStackPredicate);
+=======
+        action.queueAction(blockPos, side, useShift, context.client.player, requiredItems);
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
         Vec3 hitModifier = LitematicaUtils.usePrecisionPlacement(blockPos, context.requiredState);
         if (hitModifier != null) {
             ActionManager.INSTANCE.useProtocolHitModifier(hitModifier);
         }
         ActionManager.INSTANCE.setLook(adjustHorizontalLook(action.getPlayerLook(), context));
         ActionManager.INSTANCE.setNeedWaitModifyLookFromAction(action.isNeedWaitModifyLook());
+<<<<<<< HEAD
         boolean consumedEffectiveExecution = action.isConsumeEffectiveExecution();
         int cooldownTicks = action.getCooldownTicksOverride() >= 0
                 ? action.getCooldownTicksOverride()
@@ -163,6 +205,29 @@ public final class PrintPlacementExecutor {
             case NO_QUEUED_ACTION -> "动作未入队";
             default -> "动作未发送";
         };
+=======
+        HudStatsManager.INSTANCE.trackExpectedBlockState(HudStatsManager.Mode.PRINT, blockPos, context.requiredState);
+        HudStatsManager.INSTANCE.recordRateUnit(HudStatsManager.Mode.PRINT, 1);
+
+        boolean consumedEffectiveExecution = action.isConsumeEffectiveExecution();
+        boolean needWaitModifyLook = ActionManager.INSTANCE.sendQueue(context.client.player).needWaitModifyLook;
+        PrintPlacementResult.TaskEvent taskEvent = needWaitModifyLook
+                ? PrintPlacementResult.TaskEvent.QUEUED
+                : PrintPlacementResult.TaskEvent.SUCCESS;
+
+        if (needWaitModifyLook) {
+            HudStatsManager.INSTANCE.recordDeferred(HudStatsManager.Mode.PRINT, "等待转头");
+        } else {
+            HudStatsManager.INSTANCE.recordStatus(HudStatsManager.Mode.PRINT, "运行中");
+        }
+
+        boolean skipIteration = needWaitModifyLook
+                || shouldStopAfterTaskAction(taskAction);
+        int cooldownTicks = action.getCooldownTicksOverride() >= 0
+                ? action.getCooldownTicksOverride()
+                : ConfigUtils.getPlaceCooldown();
+        return new PrintPlacementResult(consumedEffectiveExecution, skipIteration, taskEvent, cooldownTicks);
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
     }
 
     private static boolean getUseShift(SchematicBlockContext context, Action action, Direction side) {

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/print/PrintPlacementResult.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/print/PrintPlacementResult.java
@@ -10,6 +10,7 @@ public record PrintPlacementResult(
         return new PrintPlacementResult(consumedEffectiveExecution, skipIteration, TaskEvent.FAILURE, -1);
     }
 
+<<<<<<< HEAD
     public static PrintPlacementResult cancelled(boolean skipIteration) {
         return new PrintPlacementResult(false, skipIteration, TaskEvent.CANCELLED, -1);
     }
@@ -18,6 +19,11 @@ public record PrintPlacementResult(
         SUCCESS,
         QUEUED,
         CANCELLED,
+=======
+    public enum TaskEvent {
+        SUCCESS,
+        QUEUED,
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         FAILURE
     }
 }

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/print/PrintTaskAction.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/print/PrintTaskAction.java
@@ -11,9 +11,12 @@ public interface PrintTaskAction {
 
     void onFailure(SchematicBlockContext context, Action action);
 
+<<<<<<< HEAD
     default void onCancelled(SchematicBlockContext context, Action action) {
     }
 
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     default boolean stopIterationAfterAction() {
         return true;
     }

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/print/SortedSchematicTargetQueue.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/print/SortedSchematicTargetQueue.java
@@ -40,6 +40,7 @@ public final class SortedSchematicTargetQueue {
     }
 
     private void fill(List<PrinterBox> sourceBoxes, ClientLevel level, WorldSchematic schematic, LocalPlayer player, int scanGuardLimit) {
+<<<<<<< HEAD
         if (!this.queue.isEmpty()) {
             return;
         }
@@ -64,6 +65,44 @@ public final class SortedSchematicTargetQueue {
             }
             if (queuedKeys.add(ScanCache.key(candidate))) {
                 positions.add(candidate);
+=======
+        int collectLimit = scanGuardLimit > 0 ? scanGuardLimit : Integer.MAX_VALUE;
+        boolean previousHasMoreSource = this.hasMoreSource;
+        List<BlockPos> positions = new ArrayList<>();
+        Set<Long> queuedKeys = new HashSet<>();
+        while (!this.queue.isEmpty()) {
+            BlockPos queued = this.queue.removeFirst();
+            if (!containsAny(sourceBoxes, queued)) {
+                continue;
+            }
+            positions.add(queued);
+            queuedKeys.add(ScanCache.key(queued));
+        }
+        this.hasMoreSource = positions.size() >= collectLimit && previousHasMoreSource;
+        if (positions.size() < collectLimit) {
+            Iterable<BlockPos> candidates = ScanCache.INSTANCE.iterable(
+                    "print_sorted",
+                    sourceBoxes,
+                    level,
+                    schematic,
+                    player,
+                    scanGuardLimit,
+                    ScanIntent.PRINT,
+                    pos -> true
+            );
+            for (BlockPos candidate : candidates) {
+                if (candidate == null) {
+                    this.hasMoreSource = true;
+                    break;
+                }
+                if (positions.size() >= collectLimit) {
+                    this.hasMoreSource = true;
+                    break;
+                }
+                if (queuedKeys.add(ScanCache.key(candidate))) {
+                    positions.add(candidate);
+                }
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             }
         }
         positions.sort(createComparator(schematic, player));

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/print/WaterPrintTask.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/print/WaterPrintTask.java
@@ -319,6 +319,7 @@ public class WaterPrintTask implements PrintTask {
 
         @Override
         public void onQueued(SchematicBlockContext context, Action action) {
+<<<<<<< HEAD
             refreshState(context.currentState);
         }
 
@@ -327,6 +328,9 @@ public class WaterPrintTask implements PrintTask {
             if (this.finalPlacement) {
                 complete = true;
             } else {
+=======
+            if (!this.finalPlacement) {
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
                 icePlacementSent = true;
                 iceBreakSent = false;
                 refreshState(context.currentState);
@@ -334,11 +338,20 @@ public class WaterPrintTask implements PrintTask {
         }
 
         @Override
+<<<<<<< HEAD
         public void onCancelled(SchematicBlockContext context, Action action) {
             if (!this.finalPlacement) {
                 icePlacementSent = false;
             }
             refreshState(context.currentState);
+=======
+        public void onSuccess(SchematicBlockContext context, Action action) {
+            if (this.finalPlacement) {
+                complete = true;
+            } else {
+                this.onQueued(context, action);
+            }
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         }
 
         @Override

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/scan/DirtyRegionTracker.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/scan/DirtyRegionTracker.java
@@ -13,8 +13,11 @@ public final class DirtyRegionTracker {
     public static final DirtyRegionTracker INSTANCE = new DirtyRegionTracker();
 
     public static final int REGION_SIZE = 16;
+<<<<<<< HEAD
     private static final int MAX_DIRTY_REGIONS = 8192;
     private static final long MAX_VERSION_HISTORY = 32768L;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
     private static final int XZ_BITS = 22;
     private static final int Y_BITS = 20;
@@ -86,10 +89,13 @@ public final class DirtyRegionTracker {
 
     private void markDirtyRegion(int sectionX, int sectionY, int sectionZ) {
         this.dirtyRegions.put(regionKey(sectionX, sectionY, sectionZ), ++this.version);
+<<<<<<< HEAD
         if (this.dirtyRegions.size() > MAX_DIRTY_REGIONS && (this.version & 255L) == 0L) {
             long minimumVersion = Math.max(0L, this.version - MAX_VERSION_HISTORY);
             this.dirtyRegions.long2LongEntrySet().removeIf(entry -> entry.getLongValue() < minimumVersion);
         }
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 
     private PrinterBox toBox(long key) {

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/scan/ScanCache.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/scan/ScanCache.java
@@ -13,7 +13,10 @@ import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.block.LiquidBlock;
+<<<<<<< HEAD
 import net.minecraft.world.level.block.BaseRailBlock;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.ArrayDeque;
@@ -149,6 +152,7 @@ public final class ScanCache {
         }
     }
 
+<<<<<<< HEAD
     public void resetOwner(String ownerKey) {
         if (ownerKey == null || ownerKey.isBlank()) {
             return;
@@ -157,6 +161,8 @@ public final class ScanCache {
         this.sessions.keySet().removeIf(key -> key.startsWith(prefix));
     }
 
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     public Iterable<BlockPos> rawIterable(
             String ownerKey,
             PrinterBox sourceBox,
@@ -1117,6 +1123,7 @@ public final class ScanCache {
                         return 0;
                     }
                     BlockState requiredState = schematic.getBlockState(this.liveMutable);
+<<<<<<< HEAD
                     if (requiredState.equals(state)
                             && !(requiredState.getBlock() instanceof BaseRailBlock)) {
                         return 0;
@@ -1127,6 +1134,12 @@ public final class ScanCache {
                     if (Configs.Print.BREAK_EXTRA_BLOCK.getBooleanValue()
                             && !state.isAir()
                             && !(state.getBlock() instanceof LiquidBlock)) {
+=======
+                    if (!requiredState.isAir()) {
+                        return (byte) (ScanFlags.SCHEMATIC_SAMPLED | ScanFlags.SCHEMATIC_NON_AIR);
+                    }
+                    if (!state.isAir() && !(state.getBlock() instanceof LiquidBlock)) {
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
                         return (byte) (ScanFlags.SCHEMATIC_SAMPLED | ScanFlags.WORLD_NON_AIR);
                     }
                     return 0;
@@ -1456,6 +1469,7 @@ public final class ScanCache {
                 );
                 BlockPos.MutableBlockPos first = new BlockPos.MutableBlockPos();
                 if (cursor.next(first)) {
+<<<<<<< HEAD
                     this.cursors.add(new BoxCursorNode(
                             index,
                             cursor,
@@ -1464,6 +1478,9 @@ public final class ScanCache {
                             first.getZ(),
                             region
                     ));
+=======
+                    this.cursors.add(new BoxCursorNode(index, cursor, first.immutable(), region));
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
                 }
             }
             this.complete = this.cursors.isEmpty();
@@ -1477,6 +1494,7 @@ public final class ScanCache {
         boolean next(BlockPos.MutableBlockPos target) {
             while (!this.cursors.isEmpty()) {
                 BoxCursorNode node = this.cursors.poll();
+<<<<<<< HEAD
                 int resultX = node.x;
                 int resultY = node.y;
                 int resultZ = node.z;
@@ -1490,18 +1508,36 @@ public final class ScanCache {
                     continue;
                 }
                 target.set(resultX, resultY, resultZ);
+=======
+                BlockPos result = node.pos;
+                BlockPos.MutableBlockPos following = new BlockPos.MutableBlockPos();
+                if (node.cursor.next(following)) {
+                    node.pos = following.immutable();
+                    this.cursors.add(node);
+                }
+                if (this.claimedByEarlierBox(node.boxIndex, result)) {
+                    continue;
+                }
+                target.set(result);
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
                 return true;
             }
             this.complete = true;
             return false;
         }
 
+<<<<<<< HEAD
         private boolean claimedByEarlierBox(int boxIndex, int x, int y, int z) {
             for (int index = 0; index < boxIndex; index++) {
                 PrinterBox box = this.boxes.get(index);
                 if (x >= box.minX && x <= box.maxX
                         && y >= box.minY && y <= box.maxY
                         && z >= box.minZ && z <= box.maxZ) {
+=======
+        private boolean claimedByEarlierBox(int boxIndex, BlockPos pos) {
+            for (int index = 0; index < boxIndex; index++) {
+                if (this.boxes.get(index).contains(pos)) {
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
                     return true;
                 }
             }
@@ -1514,24 +1550,36 @@ public final class ScanCache {
             private final int centerX;
             private final int centerY;
             private final int centerZ;
+<<<<<<< HEAD
             private final BlockPos.MutableBlockPos following = new BlockPos.MutableBlockPos();
             private int x;
             private int y;
             private int z;
+=======
+            private BlockPos pos;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
             private BoxCursorNode(
                     int boxIndex,
                     BoxDistanceCursor cursor,
+<<<<<<< HEAD
                     int x,
                     int y,
                     int z,
+=======
+                    BlockPos pos,
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
                     SectionRegion region
             ) {
                 this.boxIndex = boxIndex;
                 this.cursor = cursor;
+<<<<<<< HEAD
                 this.x = x;
                 this.y = y;
                 this.z = z;
+=======
+                this.pos = pos;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
                 this.centerX = region.centerX();
                 this.centerY = region.centerY();
                 this.centerZ = region.centerZ();
@@ -1543,6 +1591,7 @@ public final class ScanCache {
                 if (result != 0) {
                     return result;
                 }
+<<<<<<< HEAD
                 result = Integer.compare(this.x, other.x);
                 if (result != 0) {
                     return result;
@@ -1552,6 +1601,17 @@ public final class ScanCache {
                     return result;
                 }
                 result = Integer.compare(this.z, other.z);
+=======
+                result = Integer.compare(this.pos.getX(), other.pos.getX());
+                if (result != 0) {
+                    return result;
+                }
+                result = Integer.compare(this.pos.getY(), other.pos.getY());
+                if (result != 0) {
+                    return result;
+                }
+                result = Integer.compare(this.pos.getZ(), other.pos.getZ());
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
                 if (result != 0) {
                     return result;
                 }
@@ -1559,9 +1619,15 @@ public final class ScanCache {
             }
 
             private long distanceSqr() {
+<<<<<<< HEAD
                 long dx = this.x - (long) this.centerX;
                 long dy = this.y - (long) this.centerY;
                 long dz = this.z - (long) this.centerZ;
+=======
+                long dx = this.pos.getX() - (long) this.centerX;
+                long dy = this.pos.getY() - (long) this.centerY;
+                long dz = this.pos.getZ() - (long) this.centerZ;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
                 return dx * dx + dy * dy + dz * dz;
             }
         }
@@ -1732,6 +1798,7 @@ public final class ScanCache {
                 return new int[0];
             }
             int[] coordinates = new int[max - min + 1];
+<<<<<<< HEAD
             int pivot = Math.max(min, Math.min(max, center));
             int left = pivot;
             int right = pivot + 1;
@@ -1752,6 +1819,27 @@ public final class ScanCache {
                 } else {
                     coordinates[index++] = right++;
                 }
+=======
+            for (int index = 0; index < coordinates.length; index++) {
+                coordinates[index] = min + index;
+            }
+
+            for (int index = 1; index < coordinates.length; index++) {
+                int value = coordinates[index];
+                long valueDistance = axisDistanceSqr(value, center);
+                int insertionIndex = index;
+                while (insertionIndex > 0) {
+                    int previous = coordinates[insertionIndex - 1];
+                    long previousDistance = axisDistanceSqr(previous, center);
+                    if (previousDistance < valueDistance
+                            || previousDistance == valueDistance && previous <= value) {
+                        break;
+                    }
+                    coordinates[insertionIndex] = previous;
+                    insertionIndex--;
+                }
+                coordinates[insertionIndex] = value;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             }
             return coordinates;
         }

--- a/src/main/java/me/aleksilassila/litematica/printer/mixin/MixinClientPacketListener.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/mixin/MixinClientPacketListener.java
@@ -3,7 +3,10 @@ package me.aleksilassila.litematica.printer.mixin;
 import me.aleksilassila.litematica.printer.printer.zxy.inventory.InventoryUtils;
 import me.aleksilassila.litematica.printer.printer.zxy.inventory.SwitchItem;
 import net.minecraft.client.multiplayer.ClientPacketListener;
+<<<<<<< HEAD
 import net.minecraft.client.Minecraft;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 import net.minecraft.network.protocol.game.ClientboundContainerSetContentPacket;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,12 +14,17 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import static me.aleksilassila.litematica.printer.printer.zxy.inventory.InventoryUtils.isOpenHandler;
+<<<<<<< HEAD
+=======
+import static me.aleksilassila.litematica.printer.printer.zxy.inventory.SwitchItem.reSwitchItem;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
 @Mixin(ClientPacketListener.class)
 public abstract class MixinClientPacketListener {
 
     @Inject(at = @At("TAIL"), method = "handleContainerContent")
     public void onInventory(ClientboundContainerSetContentPacket packet, CallbackInfo ci) {
+<<<<<<< HEAD
         Minecraft client = Minecraft.getInstance();
         if (client.player == null
                 || client.player.containerMenu == client.player.inventoryMenu
@@ -34,6 +42,13 @@ public abstract class MixinClientPacketListener {
         }
         if (SwitchItem.isWaitingForRestoreContainer()) {
             SwitchItem.restorePendingItem();
+=======
+        if (isOpenHandler) {
+            InventoryUtils.switchInv();
+        }
+        if (reSwitchItem != null) {
+            SwitchItem.reSwitchItem();
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         }
     }
 }

--- a/src/main/java/me/aleksilassila/litematica/printer/mixin/printer/malilib/MixinAbstractCraftingMenu.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/mixin/printer/malilib/MixinAbstractCraftingMenu.java
@@ -34,13 +34,23 @@ public abstract class MixinAbstractCraftingMenu<TYPE, WIDGET extends WidgetListE
                     cir.setReturnValue(true);
                     return;
                 }
+<<<<<<< HEAD
                 for (String s2 : PinYinSearchUtils.getPinYin(fullName)) {
                     if (s2.contains(filterText)) {
                         cir.setReturnValue(true);
                         return;
+=======
+                for (String s2 : PinYinSearchUtils.getPinYin(fullName).stream().distinct().toList()) {
+                    if (s2.contains(filterText)) {
+                        cir.setReturnValue(true);
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
                     }
                 }
             }
         }
     }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)

--- a/src/main/java/me/aleksilassila/litematica/printer/mixin/printer/malilib/config/MixinConfigBase.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/mixin/printer/malilib/config/MixinConfigBase.java
@@ -49,6 +49,7 @@ public abstract class MixinConfigBase<T extends IConfigBase> implements IConfigB
 
     @Inject(method = "getComment", at = @At("HEAD"), cancellable = true)
     public void litematica_printer$getComment(CallbackInfoReturnable<String> cir) {
+<<<<<<< HEAD
         boolean hasCommentKey = litematica_printer$translateCommentKey != null && !litematica_printer$translateCommentKey.isEmpty();
         boolean hasNameKey = litematica_printer$translateNameKey != null && !litematica_printer$translateNameKey.isEmpty();
         if (!hasCommentKey && !hasNameKey) {
@@ -60,6 +61,13 @@ public abstract class MixinConfigBase<T extends IConfigBase> implements IConfigB
             comment = StringUtils.getTranslatedOrFallback(litematica_printer$translateCommentKey, null);
         }
         if (comment == null && hasNameKey) {
+=======
+        @Nullable String comment = null;
+        if (litematica_printer$translateCommentKey != null && !litematica_printer$translateCommentKey.isEmpty()) {
+            comment = StringUtils.getTranslatedOrFallback(litematica_printer$translateCommentKey, null);
+        }
+        if (comment == null && litematica_printer$translateNameKey != null && !litematica_printer$translateNameKey.isEmpty()) {
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             comment = StringUtils.getTranslatedOrFallback(litematica_printer$translateNameKey, null);
         }
         if (comment == null) {

--- a/src/main/java/me/aleksilassila/litematica/printer/mixin/printer/mc/MixinBlockItem.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/mixin/printer/mc/MixinBlockItem.java
@@ -2,7 +2,10 @@ package me.aleksilassila.litematica.printer.mixin.printer.mc;
 
 import fi.dy.masa.litematica.util.PlacementHandler;
 import me.aleksilassila.litematica.printer.config.Configs;
+<<<<<<< HEAD
 import me.aleksilassila.litematica.printer.printer.ActionManager;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.context.BlockPlaceContext;
@@ -28,8 +31,12 @@ public abstract class MixinBlockItem extends Item {
 
     @Inject(method = "getPlacementState", at = @At("HEAD"), cancellable = true)
     private void modifyPlacementState(BlockPlaceContext ctx, CallbackInfoReturnable<BlockState> cir) {
+<<<<<<< HEAD
         if (Configs.Print.EASY_PLACE_PROTOCOL.getBooleanValue()
                 && ActionManager.INSTANCE.isEasyPlaceProtocolActive()) {
+=======
+        if (Configs.Print.EASY_PLACE_PROTOCOL.getBooleanValue()) {
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             BlockState stateOrig = this.getBlock().getStateForPlacement(ctx);
             if (stateOrig != null && this.canPlace(ctx, stateOrig)) {
                 PlacementHandler.UseContext context = PlacementHandler.UseContext.from(ctx, ctx.getHand());
@@ -37,4 +44,8 @@ public abstract class MixinBlockItem extends Item {
             }
         }
     }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)

--- a/src/main/java/me/aleksilassila/litematica/printer/mixin/printer/mc/MixinLocalPlayer.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/mixin/printer/mc/MixinLocalPlayer.java
@@ -5,7 +5,10 @@ import fi.dy.masa.litematica.world.SchematicWorldHandler;
 import fi.dy.masa.litematica.world.WorldSchematic;
 import me.aleksilassila.litematica.printer.config.Configs;
 import me.aleksilassila.litematica.printer.handler.ClientPlayerTickManager;
+<<<<<<< HEAD
 import me.aleksilassila.litematica.printer.printer.ActionManager;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 import me.aleksilassila.litematica.printer.utils.CooldownUtils;
 import me.aleksilassila.litematica.printer.printer.zxy.inventory.InventoryUtils;
 import me.aleksilassila.litematica.printer.utils.InteractionUtils;
@@ -27,6 +30,10 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.Optional;
+<<<<<<< HEAD
+=======
+import java.util.concurrent.CompletableFuture;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
 @Mixin(LocalPlayer.class)
 public class MixinLocalPlayer extends AbstractClientPlayer {
@@ -60,7 +67,11 @@ public class MixinLocalPlayer extends AbstractClientPlayer {
             this.litematica_printer$runtimeResetDone = true;
         }
         if (Configs.Core.UPDATE_CHECK.getBooleanValue() && !updateChecked) {
+<<<<<<< HEAD
             UpdateCheckerUtils.checkForUpdates();
+=======
+            CompletableFuture.runAsync(UpdateCheckerUtils::checkForUpdates);
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         }
         updateChecked = true;
     }
@@ -87,10 +98,13 @@ public class MixinLocalPlayer extends AbstractClientPlayer {
 
     @Unique
     public void openEditSignScreen(SignBlockEntity sign, boolean front, CallbackInfo ci) {
+<<<<<<< HEAD
         if (!Configs.Core.WORK_SWITCH.getBooleanValue()
                 || !ActionManager.INSTANCE.isPrintInteractionActive()) {
             return;
         }
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         getTargetSignEntity(sign).ifPresent(signBlockEntity ->
         {
             //#if MC > 11904

--- a/src/main/java/me/aleksilassila/litematica/printer/mixin/printer/mc/MixinMultiPlayerGameMode.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/mixin/printer/mc/MixinMultiPlayerGameMode.java
@@ -78,6 +78,7 @@ public abstract class MixinMultiPlayerGameMode implements MultiPlayerGameModeExt
     @Unique
     private BlockState litematica_printer$pendingBreakSoundState;
 
+<<<<<<< HEAD
     @Override
     public void litematica_printer$resetRuntime() {
         LocalPlayer player = this.minecraft.player;
@@ -114,6 +115,12 @@ public abstract class MixinMultiPlayerGameMode implements MultiPlayerGameModeExt
                 return;
             }
             this.minecraft.level.destroyBlockProgress(playerId, pos, -1);
+=======
+    @Unique
+    private void litematica_printer$clearDestroyProgress(LocalPlayer player, BlockPos pos) {
+        if (player != null && pos != null && this.minecraft.level != null) {
+            this.minecraft.level.destroyBlockProgress(player.getId(), pos, -1);
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         }
     }
 

--- a/src/main/java/me/aleksilassila/litematica/printer/mixin_extension/MultiPlayerGameModeExtension.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/mixin_extension/MultiPlayerGameModeExtension.java
@@ -31,7 +31,10 @@ public interface MultiPlayerGameModeExtension {
     default boolean litematica_printer$isPendingDelayedDestroy(BlockPos blockPos) {
         return false;
     }
+<<<<<<< HEAD
 
     default void litematica_printer$resetRuntime() {
     }
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 }

--- a/src/main/java/me/aleksilassila/litematica/printer/printer/ActionManager.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/printer/ActionManager.java
@@ -2,6 +2,10 @@ package me.aleksilassila.litematica.printer.printer;
 
 import lombok.Setter;
 import me.aleksilassila.litematica.printer.Reference;
+<<<<<<< HEAD
+=======
+import me.aleksilassila.litematica.printer.config.Configs;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 import me.aleksilassila.litematica.printer.mixin_extension.MultiPlayerGameModeExtension;
 import me.aleksilassila.litematica.printer.printer.zxy.inventory.SwitchItem;
 import me.aleksilassila.litematica.printer.utils.minecraft.DirectionUtils;
@@ -19,10 +23,13 @@ import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+<<<<<<< HEAD
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import net.minecraft.world.item.ItemStack;
 
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 //#if MC > 12105
 import net.minecraft.network.protocol.game.ServerboundPlayerInputPacket;
 import net.minecraft.world.entity.player.Input;
@@ -46,6 +53,7 @@ public class ActionManager {
     private long lastQueuedLookTick = Long.MIN_VALUE;
     private float lastQueuedLookYaw;
     private float lastQueuedLookPitch;
+<<<<<<< HEAD
     private boolean printerInteractionActive;
     private boolean easyPlaceProtocolActive;
     private ActionSource activeSource = ActionSource.GENERIC;
@@ -75,10 +83,13 @@ public class ActionManager {
             return this == WAITING_FOR_LOOK;
         }
     }
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
     private ActionManager() {
     }
 
+<<<<<<< HEAD
     public boolean queueClick(@NotNull BlockPos target, @NotNull Direction side, @NotNull Vec3 hitModifier, boolean useShift) {
         return this.queueClick(target, side, hitModifier, useShift, 1);
     }
@@ -106,6 +117,25 @@ public class ActionManager {
         this.queuedClick = new QueuedClick(target, side, hitModifier, useShift, clickRepeatCount, source);
         this.queuedClick.expectItems(expectedItems);
         return true;
+=======
+    public void queueClick(@NotNull BlockPos target, @NotNull Direction side, @NotNull Vec3 hitModifier, boolean useShift) {
+        this.queueClick(target, side, hitModifier, useShift, 1);
+    }
+
+    public void queueClick(@NotNull BlockPos target, @NotNull Direction side, @NotNull Vec3 hitModifier, boolean useShift, int clickRepeatCount) {
+        this.queueClick(target, side, hitModifier, useShift, clickRepeatCount, null);
+    }
+
+    public void queueClick(@NotNull BlockPos target, @NotNull Direction side, @NotNull Vec3 hitModifier, boolean useShift, int clickRepeatCount, @Nullable Item[] expectedItems) {
+        if (Configs.Placement.PLACE_INTERVAL.getIntegerValue() != 0) {
+            if (this.queuedClick != null) {
+                System.out.println("Was not ready yet.");
+                return;
+            }
+        }
+        this.queuedClick = new QueuedClick(target, side, hitModifier, useShift, clickRepeatCount);
+        this.queuedClick.expectItems(expectedItems);
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 
     public void useProtocolHitModifier(@NotNull Vec3 hitModifier) {
@@ -114,6 +144,7 @@ public class ActionManager {
         }
     }
 
+<<<<<<< HEAD
     public boolean setQueueCompletionListener(@Nullable Consumer<SendResult> completionListener) {
         if (this.queuedClick == null) {
             return false;
@@ -140,6 +171,17 @@ public class ActionManager {
         }
         if (shouldDropStaleQueuedClick(player, click)) {
             return this.finish(click, SendResult.STALE_POSITION);
+=======
+    public ActionManager sendQueue(@Nullable LocalPlayer player) {
+        QueuedClick click = this.queuedClick;
+        if (click == null || player == null) {
+            clearQueue();
+            return this;
+        }
+        if (shouldDropStaleQueuedClick(player, click)) {
+            clearQueue();
+            return this;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         }
         if (!needWaitModifyLook && look != null && shouldSendQueuedLook(look)) {
             NetworkUtils.sendLookPacket(player, look);
@@ -147,13 +189,22 @@ public class ActionManager {
         }
         if (shouldWaitForServerLook(player, click)) {
             needWaitModifyLook = true;
+<<<<<<< HEAD
             return SendResult.WAITING_FOR_LOOK;
+=======
+            return this;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         }
         if (needWaitModifyLook) {
             needWaitModifyLook = false;
         }
         if (!isHoldingExpectedItem(player, click)) {
+<<<<<<< HEAD
             return this.finish(click, SendResult.HELD_ITEM_CHANGED);
+=======
+            clearQueue();
+            return this;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         }
         Direction direction;
         if (look == null) {
@@ -170,13 +221,24 @@ public class ActionManager {
         } else {
             hitVec = click.hitModifier;
         }
+<<<<<<< HEAD
         SwitchItem.onMainHandUse(player);
+=======
+        if (InventoryUtils.getOrderlyStoreItem() != null) {
+            if (InventoryUtils.getOrderlyStoreItem().isEmpty()) {
+                SwitchItem.removeItem(InventoryUtils.getOrderlyStoreItem());
+            } else {
+                SwitchItem.syncUseTime(InventoryUtils.getOrderlyStoreItem());
+            }
+        }
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         boolean wasSneak = player.isShiftKeyDown();
         if (click.useShift && !wasSneak) {
             setShift(player, true);
         } else if (!click.useShift && wasSneak) {
             setShift(player, false);
         }
+<<<<<<< HEAD
         if (!(Reference.MINECRAFT.gameMode instanceof MultiPlayerGameModeExtension gameModeExtension)) {
             restoreShift(player, click, wasSneak);
             return this.finish(click, SendResult.NO_GAME_MODE);
@@ -205,11 +267,21 @@ public class ActionManager {
     }
 
     private void restoreShift(LocalPlayer player, QueuedClick click, boolean wasSneak) {
+=======
+        MultiPlayerGameModeExtension gameModeExtension = (MultiPlayerGameModeExtension) Reference.MINECRAFT.gameMode;
+        if (gameModeExtension != null) {
+            BlockHitResult blockHitResult = new BlockHitResult(hitVec, click.side, click.target, false);
+            for (int i = 0; i < click.repeatCount; i++) {
+                gameModeExtension.litematica_printer$useItemOn(true, InteractionHand.MAIN_HAND, blockHitResult);
+            }
+        }
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         if (click.useShift && !wasSneak) {
             setShift(player, false);
         } else if (!click.useShift && wasSneak) {
             setShift(player, true);
         }
+<<<<<<< HEAD
     }
 
     private SendResult finish(QueuedClick click, SendResult result) {
@@ -233,6 +305,10 @@ public class ActionManager {
         return this.printerInteractionActive
                 && this.activeSource == ActionSource.PRINT
                 && this.easyPlaceProtocolActive;
+=======
+        clearQueue();
+        return this;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 
     public void setShift(LocalPlayer player, boolean shift) {
@@ -278,10 +354,13 @@ public class ActionManager {
     }
 
     private static boolean isHoldingExpectedItem(LocalPlayer player, QueuedClick click) {
+<<<<<<< HEAD
         if (click.expectedStackPredicate != null
                 && !click.expectedStackPredicate.test(player.getMainHandItem())) {
             return false;
         }
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         if (click.expectedItems == null || click.expectedItems.length == 0) {
             return true;
         }
@@ -320,8 +399,11 @@ public class ActionManager {
         this.waitForHorizontalLook = true;
         this.actionRequiresWaitModifyLook = false;
         this.look = null;
+<<<<<<< HEAD
         this.printerInteractionActive = false;
         this.easyPlaceProtocolActive = false;
         this.activeSource = ActionSource.GENERIC;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 }

--- a/src/main/java/me/aleksilassila/litematica/printer/printer/QueuedClick.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/printer/QueuedClick.java
@@ -8,10 +8,13 @@ import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+<<<<<<< HEAD
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import net.minecraft.world.item.ItemStack;
 
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 final class QueuedClick {
     final BlockPos target;
     final Direction side;
@@ -19,12 +22,16 @@ final class QueuedClick {
     final boolean useShift;
     boolean useProtocol;
     final int repeatCount;
+<<<<<<< HEAD
     final ActionManager.ActionSource source;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     @Nullable
     final Vec3 queuedPlayerPosition;
     final long queuedTick;
     @Nullable
     Item[] expectedItems;
+<<<<<<< HEAD
     @Nullable
     Consumer<ActionManager.SendResult> completionListener;
     @Nullable
@@ -38,12 +45,19 @@ final class QueuedClick {
             int repeatCount,
             @NotNull ActionManager.ActionSource source
     ) {
+=======
+
+    QueuedClick(@NotNull BlockPos target, @NotNull Direction side, @NotNull Vec3 hitModifier, boolean useShift, int repeatCount) {
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         this.target = target;
         this.side = side;
         this.hitModifier = hitModifier;
         this.useShift = useShift;
         this.repeatCount = Math.max(1, repeatCount);
+<<<<<<< HEAD
         this.source = source;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         Minecraft client = Minecraft.getInstance();
         this.queuedPlayerPosition = client.player == null ? null : client.player.position();
         this.queuedTick = client.level == null ? Long.MIN_VALUE : client.level.getGameTime();
@@ -57,6 +71,7 @@ final class QueuedClick {
     void expectItems(@Nullable Item[] expectedItems) {
         this.expectedItems = expectedItems == null ? null : expectedItems.clone();
     }
+<<<<<<< HEAD
 
     void onCompletion(@Nullable Consumer<ActionManager.SendResult> completionListener) {
         this.completionListener = completionListener;
@@ -65,4 +80,6 @@ final class QueuedClick {
     void expectStack(@Nullable Predicate<ItemStack> expectedStackPredicate) {
         this.expectedStackPredicate = expectedStackPredicate;
     }
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 }

--- a/src/main/java/me/aleksilassila/litematica/printer/printer/action/Action.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/printer/action/Action.java
@@ -21,8 +21,11 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+<<<<<<< HEAD
 import java.util.function.Predicate;
 import net.minecraft.world.item.ItemStack;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
 @SuppressWarnings("UnusedReturnValue")
 public class Action {
@@ -54,12 +57,15 @@ public class Action {
     protected int clickRepeatCount = 1;
     @Getter
     protected boolean needWaitModifyLook = false;
+<<<<<<< HEAD
     @Getter
     @Nullable
     protected Predicate<ItemStack> requiredStackPredicate;
     @Getter
     @Nullable
     protected ItemStack requiredCreativeStack;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
     public Action() {
         this.sides = createDefaultSides();
@@ -215,6 +221,7 @@ public class Action {
         return this.setShift(true);
     }
 
+<<<<<<< HEAD
     public Action setRequiredStackPredicate(@Nullable Predicate<ItemStack> requiredStackPredicate) {
         this.requiredStackPredicate = requiredStackPredicate;
         return this;
@@ -225,6 +232,8 @@ public class Action {
         return this;
     }
 
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     public Action setConsumeEffectiveExecution(boolean consumeEffectiveExecution) {
         this.consumeEffectiveExecution = consumeEffectiveExecution;
         return this;
@@ -240,6 +249,7 @@ public class Action {
         return this;
     }
 
+<<<<<<< HEAD
     public boolean queueAction(@NotNull BlockPos blockPos, @NotNull Direction side, boolean useShift, @NotNull LocalPlayer player) {
         return this.queueAction(blockPos, side, useShift, player, null);
     }
@@ -247,25 +257,48 @@ public class Action {
     public boolean queueAction(@NotNull BlockPos blockPos, @NotNull Direction side, boolean useShift, @NotNull LocalPlayer player, @Nullable Item[] expectedItems) {
         if (Configs.Print.PLACE_IN_AIR.getBooleanValue() && !this.requiresSupport) {
             return ActionManager.INSTANCE.queueClick(
+=======
+    public Action queueAction(@NotNull BlockPos blockPos, @NotNull Direction side, boolean useShift, @NotNull LocalPlayer player) {
+        return this.queueAction(blockPos, side, useShift, player, null);
+    }
+
+    public Action queueAction(@NotNull BlockPos blockPos, @NotNull Direction side, boolean useShift, @NotNull LocalPlayer player, @Nullable Item[] expectedItems) {
+        if (Configs.Print.PLACE_IN_AIR.getBooleanValue() && !this.requiresSupport) {
+            ActionManager.INSTANCE.queueClick(
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
                     blockPos,
                     side.getOpposite(),
                     getSides().get(side),
                     useShift,
                     1,
+<<<<<<< HEAD
                     expectedItems,
                     ActionManager.ActionSource.PRINT
             );
         } else {
             return ActionManager.INSTANCE.queueClick(
+=======
+                    expectedItems
+            );
+        } else {
+            ActionManager.INSTANCE.queueClick(
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
                     blockPos.relative(side),
                     side.getOpposite(),
                     getSides().get(side),
                     useShift,
                     1,
+<<<<<<< HEAD
                     expectedItems,
                     ActionManager.ActionSource.PRINT
             );
         }
+=======
+                    expectedItems
+            );
+        }
+        return this;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 
     private static @NotNull Map<Direction, Vec3> createDefaultSides() {

--- a/src/main/java/me/aleksilassila/litematica/printer/printer/action/ClickAction.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/printer/action/ClickAction.java
@@ -12,11 +12,16 @@ import org.jetbrains.annotations.Nullable;
 
 public class ClickAction extends Action {
     @Override
+<<<<<<< HEAD
     public boolean queueAction(@NotNull BlockPos blockPos, @NotNull Direction side, boolean useShift, @NotNull LocalPlayer player) {
+=======
+    public Action queueAction(@NotNull BlockPos blockPos, @NotNull Direction side, boolean useShift, @NotNull LocalPlayer player) {
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         return this.queueAction(blockPos, side, useShift, player, null);
     }
 
     @Override
+<<<<<<< HEAD
     public boolean queueAction(@NotNull BlockPos blockPos, @NotNull Direction side, boolean useShift, @NotNull LocalPlayer player, @Nullable Item[] expectedItems) {
         return ActionManager.INSTANCE.queueClick(
                 blockPos,
@@ -27,6 +32,11 @@ public class ClickAction extends Action {
                 expectedItems,
                 ActionManager.ActionSource.PRINT
         );
+=======
+    public Action queueAction(@NotNull BlockPos blockPos, @NotNull Direction side, boolean useShift, @NotNull LocalPlayer player, @Nullable Item[] expectedItems) {
+        ActionManager.INSTANCE.queueClick(blockPos, side, getSides().get(side), false, this.clickRepeatCount, expectedItems);
+        return this;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 
     @Override

--- a/src/main/java/me/aleksilassila/litematica/printer/printer/zxy/inventory/InventoryUtils.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/printer/zxy/inventory/InventoryUtils.java
@@ -1,7 +1,10 @@
 package me.aleksilassila.litematica.printer.printer.zxy.inventory;
 
 import me.aleksilassila.litematica.printer.I18n;
+<<<<<<< HEAD
 import me.aleksilassila.litematica.printer.Reference;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 import me.aleksilassila.litematica.printer.utils.minecraft.MessageUtils;
 import me.aleksilassila.litematica.printer.utils.mods.ModLoadUtils;
 import me.aleksilassila.litematica.printer.utils.mods.ShulkerUtils;
@@ -117,6 +120,7 @@ public class InventoryUtils {
         ModLoadUtils.closeScreen = 0;
     }
 
+<<<<<<< HEAD
     static int shulkerInventoryMenuSlot = -1;
 
     public static void switchInv() {
@@ -125,11 +129,18 @@ public class InventoryUtils {
             clearSwitchRequest();
             return;
         }
+=======
+    static int shulkerBoxSlot = -1;
+
+    public static void switchInv() {
+        LocalPlayer player = Minecraft.getInstance().player;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         AbstractContainerMenu sc = player.containerMenu;
         if (sc.equals(player.inventoryMenu)) {
             return;
         }
         NonNullList<Slot> slots = sc.slots;
+<<<<<<< HEAD
         if (slots.isEmpty()) {
             clearSwitchRequest();
             player.closeContainer();
@@ -138,6 +149,10 @@ public class InventoryUtils {
         for (Item item : lastNeedItemList) {
             int containerSize = Math.min(slots.size(), slots.get(0).container.getContainerSize());
             for (int y = 0; y < containerSize; y++) {
+=======
+        for (Item item : lastNeedItemList) {
+            for (int y = 0; y < slots.get(0).container.getContainerSize(); y++) {
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
                 if (slots.get(y).getItem().getItem().equals(item)) {
                     String[] str = fi.dy.masa.litematica.config.Configs.Generic.PICK_BLOCKABLE_SLOTS.getStringValue().split(",");
                     if (str.length == 0) return;
@@ -150,10 +165,15 @@ public class InventoryUtils {
                                 MessageUtils.setOverlayMessage(I18n.INVENTORY_SHULKER_OCCUPIED.getName(), false);
                                 continue;
                             }
+<<<<<<< HEAD
+=======
+                            SwitchItem.newItem(slots.get(y).getItem(), y, shulkerBoxSlot);
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
                             int a = InventoryUtilsAccessor.getEmptyPickBlockableHotbarSlot(player.getInventory()) == -1 ?
                                     InventoryUtilsAccessor.getPickBlockTargetSlot(player) :
                                     InventoryUtilsAccessor.getEmptyPickBlockableHotbarSlot(player.getInventory());
                             c = a == -1 ? c : a;
+<<<<<<< HEAD
                             ItemStack retrievedStack = slots.get(y).getItem().copy();
                             ItemStack sourceShulker = player.inventoryMenu.slots
                                     .get(shulkerInventoryMenuSlot).getItem().copy();
@@ -167,14 +187,30 @@ public class InventoryUtils {
                                     shulkerInventoryMenuSlot,
                                     c
                             );
+=======
+                            ZxyUtils.switchPlayerInvToHotbarAir(c);
+                            fi.dy.masa.malilib.util.InventoryUtils.swapSlots(sc, y, c);
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
                             me.aleksilassila.litematica.printer.utils.InventoryUtils.setSelectedSlot(player.getInventory(), c);
                             me.aleksilassila.litematica.printer.utils.InventoryUtils.syncSelectedHotbarSlot();
                             me.aleksilassila.litematica.printer.utils.InventorySwitchGuard.markSwitchIfNeeded(item);
                             player.closeContainer();
+<<<<<<< HEAD
                             clearSwitchRequest();
                             return;
                         } catch (Exception e) {
                             Reference.LOGGER.warn("Quick Shulker 物品切换失败", e);
+=======
+                            //刷新濳影盒
+                            if (shulkerBoxSlot != -1) {
+                                client.gameMode.handleContainerInput(sc.containerId, shulkerBoxSlot, 0, ContainerInput.PICKUP, client.player);
+                                client.gameMode.handleContainerInput(sc.containerId, shulkerBoxSlot, 0, ContainerInput.PICKUP, client.player);
+                            }
+                            clearSwitchRequest();
+                            return;
+                        } catch (Exception e) {
+                            System.out.println("Item switch error");
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
                         }
                     }
                 }
@@ -200,9 +236,15 @@ public class InventoryUtils {
                     NonNullList<ItemStack> items1 = fi.dy.masa.malilib.util.InventoryUtils.getStoredItems(stack, -1);
                     if (items1.stream().anyMatch(s1 -> s1.getItem().equals(item))) {
                         try {
+<<<<<<< HEAD
                             shulkerInventoryMenuSlot = i;
                             if (!ShulkerUtils.openShulker(stack, shulkerInventoryMenuSlot)) {
                                 shulkerInventoryMenuSlot = -1;
+=======
+                            shulkerBoxSlot = i;
+                            if (!ShulkerUtils.openShulker(stack, shulkerBoxSlot)) {
+                                shulkerBoxSlot = -1;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
                                 continue;
                             }
                             ModLoadUtils.closeScreen++;
@@ -220,7 +262,10 @@ public class InventoryUtils {
     }
 
     public static void tick() {
+<<<<<<< HEAD
         SwitchItem.tick();
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         if (ModLoadUtils.closeScreen > 0) {
             ModLoadUtils.closeScreen--;
         }
@@ -233,7 +278,11 @@ public class InventoryUtils {
     }
 
     private static void clearSwitchRequest() {
+<<<<<<< HEAD
         shulkerInventoryMenuSlot = -1;
+=======
+        shulkerBoxSlot = -1;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         lastNeedItemList = new LinkedHashSet<>();
         isOpenHandler = false;
         openHandlerTimeout = 0;

--- a/src/main/java/me/aleksilassila/litematica/printer/printer/zxy/inventory/SwitchItem.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/printer/zxy/inventory/SwitchItem.java
@@ -7,12 +7,16 @@ import me.aleksilassila.litematica.printer.utils.mods.ModLoadUtils;
 import me.aleksilassila.litematica.printer.utils.mods.ShulkerUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
+<<<<<<< HEAD
 import net.minecraft.core.registries.BuiltInRegistries;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
+<<<<<<< HEAD
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -96,10 +100,62 @@ public class SwitchItem {
         }
         if (statistics != null) {
             statistics.syncUseTime();
+=======
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class SwitchItem {
+    @NotNull
+    static Minecraft client = Minecraft.getInstance();
+    public static ItemStack reSwitchItem = null;
+    public static Map<ItemStack, ItemStatistics> itemStacks = new HashMap<>();
+
+    public static void removeItem(ItemStack itemStack) {
+        itemStacks.remove(itemStack);
+    }
+
+    public static void syncUseTime(ItemStack itemStack) {
+        ItemStatistics itemStatistics = itemStacks.get(itemStack);
+        if (itemStatistics != null) itemStatistics.syncUseTime();
+    }
+
+    public static void newItem(ItemStack itemStack, int slot, int shulkerBox) {
+        if (shulkerBox != -1) itemStacks.put(itemStack, new ItemStatistics(slot, shulkerBox));
+    }
+
+    public static void openInv(ItemStack itemStack) {
+        if (!client.player.containerMenu.equals(client.player.inventoryMenu) || ModLoadUtils.closeScreen > 0) {
+            return;
+        }
+        AbstractContainerMenu sc = client.player.containerMenu;
+        if (sc.slots.stream().skip(9).limit(sc.slots.size() - 10)
+                .noneMatch(slot -> InventoryUtils.areStacksEqual(slot.getItem(), reSwitchItem))) {
+            itemStacks.remove(reSwitchItem);
+            reSwitchItem = null;
+            return;
+        }
+        ItemStatistics itemStatistics = itemStacks.get(itemStack);
+        if (itemStatistics != null) {
+            if (ShulkerUtils.openShulker(sc.slots.get(itemStatistics.shulkerBoxSlot).getItem(), itemStatistics.shulkerBoxSlot)) {
+                ModLoadUtils.closeScreen++;
+            } else {
+                removeItem(reSwitchItem);
+                reSwitchItem = null;
+            }
+        } else {
+            removeItem(reSwitchItem);
+            reSwitchItem = null;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         }
     }
 
     /**
+<<<<<<< HEAD
      * Select the least recently used tracked stack and open the most likely source shulker.
      */
     public static void checkItems() {
@@ -587,6 +643,90 @@ public class SwitchItem {
         }
 
         private void syncUseTime() {
+=======
+     * 检查所有已记录的物品，找到最近一次使用的物品（useTime最小），
+     * 并尝试自动打开该物品的背包界面进行操作。
+     * 如果没有可用物品，则在游戏界面显示“背包已满，请先清理”的提示。
+     */
+    public static void checkItems() {
+        final long[] min = {System.currentTimeMillis()};
+        AtomicReference<ItemStack> key = new AtomicReference<>();
+        itemStacks.keySet().forEach(k -> {
+            long useTime = itemStacks.get(k).useTime;
+            if (useTime < min[0]) {
+                min[0] = useTime;
+                key.set(k);
+            }
+        });
+        ItemStack itemStack = key.get();
+        if (itemStack != null) {
+            reSwitchItem = itemStack;
+            openInv(itemStack);
+        } else MessageUtils.setOverlayMessage(I18n.INVENTORY_FULL.getName(), false);
+    }
+
+    public static void reSwitchItem() {
+        if (client.player == null || reSwitchItem == null) return;
+        LocalPlayer player = client.player;
+        AbstractContainerMenu sc = player.containerMenu;
+        if (sc.equals(player.inventoryMenu)) return;
+
+        List<Integer> sameItem = new ArrayList<>();
+        for (int i = 0; i < sc.slots.size(); i++) {
+            Slot slot = sc.slots.get(i);
+            if (!(slot.container instanceof Inventory) &&
+                    InventoryUtils.areStacksEqual(reSwitchItem, slot.getItem()) &&
+                    slot.getItem().getCount() < slot.getItem().getMaxStackSize()
+            ) sameItem.add(i);
+            if (slot.container instanceof Inventory && client.gameMode != null && InventoryUtils.areStacksEqual(slot.getItem(), reSwitchItem)) {
+                int slot1 = itemStacks.get(reSwitchItem).slot;
+                boolean reInv = false;
+                //检查记录的槽位是否有物品
+                if (sc.slots.get(slot1).getItem().isEmpty()) {
+                    client.gameMode.handleContainerInput(sc.containerId, i, 0, ContainerInput.PICKUP, client.player);
+                    client.gameMode.handleContainerInput(sc.containerId, slot1, 0, ContainerInput.PICKUP, client.player);
+                    reInv = true;
+                } else {
+                    int count = reSwitchItem.getCount();
+                    client.gameMode.handleContainerInput(sc.containerId, i, 0, ContainerInput.PICKUP, client.player);
+                    for (Integer integer : sameItem) {
+                        int count1 = sc.slots.get(integer).getItem().getCount();
+                        int maxCount = sc.slots.get(integer).getItem().getMaxStackSize();
+                        int i1 = maxCount - count1;
+                        count -= i1;
+                        client.gameMode.handleContainerInput(sc.containerId, integer, 0, ContainerInput.PICKUP, client.player);
+                        if (count <= 0) reInv = true;
+                    }
+                }
+                removeItem(reSwitchItem);
+                reSwitchItem = null;
+                player.closeContainer();
+                if (!reInv) {
+                    MessageUtils.setOverlayMessage(I18n.INVENTORY_RESTORE_FAILED.getName(), false);
+                }
+                client.gameMode.handleContainerInput(sc.containerId, i, 0, ContainerInput.PICKUP, client.player);
+                return;
+            }
+        }
+    }
+
+    public static void reSet() {
+        reSwitchItem = null;
+        itemStacks = new HashMap<>();
+    }
+
+    public static class ItemStatistics {
+        public int slot;
+        public int shulkerBoxSlot;
+        public long useTime = System.currentTimeMillis();
+
+        public ItemStatistics(int slot, int shulkerBox) {
+            this.slot = slot;
+            this.shulkerBoxSlot = shulkerBox;
+        }
+
+        public void syncUseTime() {
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             this.useTime = System.currentTimeMillis();
         }
     }

--- a/src/main/java/me/aleksilassila/litematica/printer/printer/zxy/utils/ZxyUtils.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/printer/zxy/utils/ZxyUtils.java
@@ -11,12 +11,18 @@ import net.minecraft.world.inventory.Slot;
 public class ZxyUtils {
     private static final Minecraft client = Minecraft.getInstance();
 
+<<<<<<< HEAD
     public static int switchPlayerInvToHotbarAir(int slot) {
         if (client.player == null) return -1;
+=======
+    public static void switchPlayerInvToHotbarAir(int slot) {
+        if (client.player == null) return;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         LocalPlayer player = client.player;
         AbstractContainerMenu sc = player.containerMenu;
         NonNullList<Slot> slots = sc.slots;
         int i = sc.equals(player.inventoryMenu) ? 9 : 0;
+<<<<<<< HEAD
         int playerSlotOrdinal = 0;
         for (; i < slots.size(); i++) {
             if (!(slots.get(i).container instanceof Inventory)) {
@@ -29,6 +35,14 @@ public class ZxyUtils {
             playerSlotOrdinal++;
         }
         return -1;
+=======
+        for (; i < slots.size(); i++) {
+            if (slots.get(i).getItem().isEmpty() && slots.get(i).container instanceof Inventory) {
+                fi.dy.masa.malilib.util.InventoryUtils.swapSlots(sc, i, slot);
+                return;
+            }
+        }
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 
     public static void exitGameReSet() {

--- a/src/main/java/me/aleksilassila/litematica/printer/render/Render2D.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/render/Render2D.java
@@ -492,10 +492,14 @@ public class Render2D {
         return switch (mode) {
             case PRINT, FILL, FLUID -> Configs.Placement.PLACE_BLOCKS_PER_TICK.getIntegerValue()
                     + "/t 间隔" + Configs.Placement.PLACE_INTERVAL.getIntegerValue();
+<<<<<<< HEAD
             case MINE -> (Configs.Break.BREAK_BLOCKS_PER_TICK.getIntegerValue() == 0
                     ? "不限速"
                     : Configs.Break.BREAK_BLOCKS_PER_TICK.getIntegerValue() + "/t")
                     + " 间隔" + Configs.Break.BREAK_INTERVAL.getIntegerValue();
+=======
+            case MINE -> "不限速";
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             case BEDROCK -> Configs.Bedrock.BEDROCK_BLOCKS_PER_TICK.getIntegerValue()
                     + "/t 间隔" + Configs.Bedrock.BEDROCK_INTERVAL.getIntegerValue();
             case TOTAL -> "--";

--- a/src/main/java/me/aleksilassila/litematica/printer/utils/FilterUtils.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/utils/FilterUtils.java
@@ -114,6 +114,7 @@ public class FilterUtils {
             return false;
         }
 
+<<<<<<< HEAD
         if (matchString(targetDisplayName, coreName, matchRules)
                 || matchString(targetRegistryName, coreName, matchRules)) {
             return true;
@@ -121,6 +122,19 @@ public class FilterUtils {
         return PinYinSearchUtils.getPinYin(targetDisplayName)
                 .stream()
                 .anyMatch(pinyin -> matchString(pinyin, coreName, matchRules));
+=======
+        // 中文名称匹配
+        boolean displayNameMatch = matchString(targetDisplayName, coreName, matchRules);
+        // 拼音匹配
+        boolean pinyinMatch = PinYinSearchUtils.getPinYin(targetDisplayName)
+                .stream()
+                .anyMatch(pinyin -> matchString(pinyin, coreName, matchRules));
+        // 注册表名称匹配
+        boolean registryNameMatch = matchString(targetRegistryName, coreName, matchRules);
+
+        // 任一匹配成功即返回 true
+        return displayNameMatch || pinyinMatch || registryNameMatch;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 
     private static ParsedFilter parseExpectedName(String expectedName) {
@@ -225,6 +239,7 @@ public class FilterUtils {
             return false;
         }
 
+<<<<<<< HEAD
         if (matchString(targetDisplayName, coreName, matchRules)
                 || matchString(targetRegistryName, coreName, matchRules)) {
             return true;
@@ -232,6 +247,15 @@ public class FilterUtils {
         return PinYinSearchUtils.getPinYin(targetDisplayName)
                 .stream()
                 .anyMatch(pinyin -> matchString(pinyin, coreName, matchRules));
+=======
+        boolean displayNameMatch = matchString(targetDisplayName, coreName, matchRules);
+        boolean pinyinMatch = PinYinSearchUtils.getPinYin(targetDisplayName)
+                .stream()
+                .anyMatch(pinyin -> matchString(pinyin, coreName, matchRules));
+        boolean registryNameMatch = matchString(targetRegistryName, coreName, matchRules);
+
+        return displayNameMatch || pinyinMatch || registryNameMatch;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 
     private static Property<?> findPropertyByName(BlockState blockState, String propertyName) {

--- a/src/main/java/me/aleksilassila/litematica/printer/utils/InteractionUtils.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/utils/InteractionUtils.java
@@ -52,7 +52,11 @@ public class InteractionUtils {
     public static boolean canBreakBlock(BlockPos pos) {
         ClientLevel world = client.level;
         LocalPlayer player = client.player;
+<<<<<<< HEAD
         if (world == null || player == null || client.gameMode == null) return false;
+=======
+        if (world == null || player == null) return false;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         BlockState currentState = world.getBlockState(pos);
         if (Configs.Break.BREAK_CHECK_HARDNESS.getBooleanValue() && currentState.getBlock().defaultDestroyTime() < 0) {
             return false;
@@ -252,6 +256,7 @@ public class InteractionUtils {
                 onTick();
                 return;
             }
+<<<<<<< HEAD
             BlockBreakResult result = continueDestroyBlock(breakPos, Direction.DOWN);
             if (result != BlockBreakResult.IN_PROGRESS) {
                 if (result == BlockBreakResult.COMPLETED || result == BlockBreakResult.COMPLETED_WAIT) {
@@ -260,6 +265,10 @@ public class InteractionUtils {
                         this.markPendingBroken(breakPos, ConfigUtils.getBreakCooldown());
                     }
                 }
+=======
+            if (continueDestroyBlock(breakPos, Direction.DOWN) != BlockBreakResult.IN_PROGRESS) {
+                this.markRecentlyBroken(breakPos);
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
                 breakPos = null;
                 this.forceDelayedDestroy = false;
                 onTick();
@@ -307,9 +316,12 @@ public class InteractionUtils {
 
     public BlockBreakResult continueDestroyBlock(final BlockPos blockPos, Direction direction, boolean localPrediction, boolean trackBreakPos) {
         MultiPlayerGameModeExtension gameMode = (@Nullable MultiPlayerGameModeExtension) client.gameMode;
+<<<<<<< HEAD
         if (gameMode == null || blockPos == null || direction == null) {
             return BlockBreakResult.FAILED;
         }
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         BlockBreakResult result = gameMode.litematica_printer$continueDestroyBlock(localPrediction, blockPos, direction, this.forceDelayedDestroy);
         if (trackBreakPos && result == BlockBreakResult.IN_PROGRESS) {
             breakPos = blockPos;
@@ -388,9 +400,12 @@ public class InteractionUtils {
 
     public InteractionResult useItemOn(boolean localPrediction, InteractionHand hand, BlockHitResult blockHit) {
         MultiPlayerGameModeExtension gameMode = (@Nullable MultiPlayerGameModeExtension) client.gameMode;
+<<<<<<< HEAD
         if (gameMode == null || hand == null || blockHit == null) {
             return InteractionResult.FAIL;
         }
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         return gameMode.litematica_printer$useItemOn(localPrediction, hand, blockHit);
     }
 

--- a/src/main/java/me/aleksilassila/litematica/printer/utils/InventoryUtils.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/utils/InventoryUtils.java
@@ -3,14 +3,26 @@ package me.aleksilassila.litematica.printer.utils;
 import fi.dy.masa.litematica.util.EntityUtils;
 import fi.dy.masa.malilib.gui.Message;
 import fi.dy.masa.malilib.util.InfoUtils;
+<<<<<<< HEAD
 import me.aleksilassila.litematica.printer.mixin.printer.litematica.EasyPlaceUtilsAccessor;
 import me.aleksilassila.litematica.printer.mixin.printer.litematica.InventoryUtilsAccessor;
+=======
+import lombok.Getter;
+import lombok.Setter;
+import me.aleksilassila.litematica.printer.mixin.printer.litematica.EasyPlaceUtilsAccessor;
+import me.aleksilassila.litematica.printer.mixin.printer.litematica.InventoryUtilsAccessor;
+import me.aleksilassila.litematica.printer.utils.minecraft.MessageUtils;
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
 import me.aleksilassila.litematica.printer.utils.minecraft.PlayerUtils;
 import me.aleksilassila.litematica.printer.utils.mods.TakeItOutUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.NonNullList;
+<<<<<<< HEAD
+=======
+import net.minecraft.network.chat.Component;
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
 import net.minecraft.network.protocol.game.ServerboundSetCarriedItemPacket;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
@@ -21,6 +33,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.state.BlockState;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+<<<<<<< HEAD
 import java.util.function.Predicate;
 
 //#if MC >= 12005
@@ -30,6 +43,8 @@ import net.minecraft.world.item.alchemy.PotionContents;
 //$$ import net.minecraft.world.item.alchemy.PotionUtils;
 //#endif
 import net.minecraft.world.item.alchemy.Potions;
+=======
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
 
 import static fi.dy.masa.malilib.util.InventoryUtils.*;
 import static me.aleksilassila.litematica.printer.printer.zxy.inventory.InventoryUtils.lastNeedItemList;
@@ -40,6 +55,13 @@ public class InventoryUtils {
     private static final int OFFHAND_SLOT_INDEX = 40;
     private static final long MESSAGE_COOLDOWN_MS = 5000L;
     private static final Map<String, Long> LAST_MESSAGE_SEND_TIME = new ConcurrentHashMap<>();
+<<<<<<< HEAD
+=======
+    @Getter
+    @Setter
+    private static ItemStack orderlyStoreItem; //有序存放临时存储
+
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
     public static int getSelectedSlot(Inventory inventory) {
         //#if MC > 12104
         return inventory.getSelectedSlot();
@@ -68,6 +90,7 @@ public class InventoryUtils {
         return playerHasAccessToItems(playerEntity, item);
     }
 
+<<<<<<< HEAD
     public static boolean playerHasItemInInventory(LocalPlayer playerEntity, Item item) {
         if (playerEntity == null || item == null) {
             return false;
@@ -99,6 +122,19 @@ public class InventoryUtils {
             }
         }
         for (Item item : items) {
+=======
+    public static boolean playerHasAccessToItems(LocalPlayer playerEntity, Item... items) {
+        if (items == null || items.length == 0) return true;
+        if (PlayerUtils.getAbilities(playerEntity).mayBuild) return true;
+        if (!playerEntity.containerMenu.equals(playerEntity.inventoryMenu)) return false;
+        Inventory inventory = playerEntity.getInventory();
+        for (Item item : items) {
+            for (int i = 0; i < inventory.getContainerSize(); i++) {
+                if (inventory.getItem(i).getItem() == item) {
+                    return true;
+                }
+            }
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
             me.aleksilassila.litematica.printer.printer.zxy.inventory.InventoryUtils.lastNeedItemList.add(item);
         }
         return false;
@@ -350,6 +386,10 @@ public class InventoryUtils {
         ItemStack mainHandStack = player.getMainHandItem();
         for (Item item : items) {
             if (mainHandStack.getItem().equals(item)) {
+<<<<<<< HEAD
+=======
+                orderlyStoreItem = mainHandStack;
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
                 return true;
             }
         }
@@ -362,6 +402,7 @@ public class InventoryUtils {
             }
             return false;
         }
+<<<<<<< HEAD
         // 先检查全部可接受物品，避免首选物品缺失时提前发起取货，
         // 而背包里其实已经有后备物品（例如打火石/火焰弹）。
         for (Item item : items) {
@@ -383,11 +424,36 @@ public class InventoryUtils {
             }
         }
         for (Item item : items) {
+=======
+        // 找到背包中可用的物品
+        for (Item item : items) {
+            int slot = -1;
+            for (int i = 0; i < inventory.getContainerSize(); i++) {
+                ItemStack itemStack = inventory.getItem(i);
+                if (itemStack.getItem().equals(item)) {
+                    slot = i;
+                    break;
+                }
+            }
+            if (slot != -1) {
+                ItemStack itemStack = inventory.getItem(slot);
+                orderlyStoreItem = itemStack;
+                boolean needsInventoryConfirmation = !Inventory.isHotbarSlot(slot);
+                if (InventoryUtils.setPickedItemToHand(slot, itemStack, client)) {
+                    return !needsInventoryConfirmation || !InventorySwitchGuard.markSwitchIfNeeded(item);
+                }
+                return false;
+            }
+            if (TakeItOutUtils.tryRequestItem(item)) {
+                return false;
+            }
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
             lastNeedItemList.add(item);
         }
         return false;
     }
 
+<<<<<<< HEAD
     public static boolean playerHasAccessToMatchingStack(
             LocalPlayer playerEntity,
             ItemStack creativeFallback,
@@ -408,6 +474,73 @@ public class InventoryUtils {
             if (!stack.isEmpty() && predicate.test(stack)) {
                 return true;
             }
+=======
+    public static void setOverlayMessageWithCooldown(Component message, String cooldownKey) {
+        long currentTime = System.currentTimeMillis();
+        long lastSendTime = LAST_MESSAGE_SEND_TIME.getOrDefault(cooldownKey, 0L);
+
+        if (currentTime - lastSendTime < MESSAGE_COOLDOWN_MS) {
+            return;
+        }
+
+        MessageUtils.setOverlayMessage(message);
+        LAST_MESSAGE_SEND_TIME.put(cooldownKey, currentTime);
+    }
+
+    public static int getItemCount(LocalPlayer player, Item item) {
+        if (player == null || item == null || item == Items.AIR) {
+            return 0;
+        }
+        int count = 0;
+        Inventory inventory = player.getInventory();
+        for (int i = 0; i < inventory.getContainerSize(); i++) {
+            ItemStack stack = inventory.getItem(i);
+            if (stack.getItem().equals(item)) {
+                count += stack.getCount();
+            }
+        }
+        return count;
+    }
+
+    public static boolean hasEnoughItemsForReserve(LocalPlayer player, Item[] items, int reserveCount) {
+        if (player == null || reserveCount <= 0 || items == null || items.length == 0) {
+            return true;
+        }
+        if (PlayerUtils.getAbilities(player).instabuild) {
+            return true;
+        }
+        for (Item item : items) {
+            if (item == null || item == Items.AIR) {
+                return true;
+            }
+            if (getItemCount(player, item) > reserveCount) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean switchToItemsWithReserve(LocalPlayer player, Item[] items, int reserveCount) {
+        if (reserveCount <= 0 || PlayerUtils.getAbilities(player).instabuild) {
+            return switchToItems(player, items);
+        }
+        if (items == null || items.length == 0) {
+            return switchToItems(player, items);
+        }
+        Item selectedItem = null;
+        for (Item item : items) {
+            if (item == null || item == Items.AIR) {
+                selectedItem = item;
+                break;
+            }
+            if (getItemCount(player, item) > reserveCount) {
+                selectedItem = item;
+                break;
+            }
+        }
+        if (selectedItem != null) {
+            return switchToItems(player, new Item[]{selectedItem});
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
         }
         return false;
     }
@@ -425,6 +558,7 @@ public class InventoryUtils {
         return false;
     }
 
+<<<<<<< HEAD
     public static boolean switchToMatchingStack(
             LocalPlayer player,
             Predicate<ItemStack> predicate,
@@ -480,6 +614,8 @@ public class InventoryUtils {
         //#endif
     }
 
+=======
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
     /**
      * 检查是否能切换到目标物品（配合槽位检查，仅判断不执行切换）
      *

--- a/src/main/java/me/aleksilassila/litematica/printer/utils/PinYinSearchUtils.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/utils/PinYinSearchUtils.java
@@ -10,10 +10,14 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+<<<<<<< HEAD
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+=======
+import java.util.List;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
 /**
  * 拼音搜索工具类：将中文字符串转换为全拼/简拼组合，支持拼音包含性判断
@@ -22,6 +26,7 @@ import java.util.Map;
 public class PinYinSearchUtils {
     // 复用拼音格式配置（常量），避免重复创建
     private static final HanyuPinyinOutputFormat PINYIN_FORMAT;
+<<<<<<< HEAD
     private static final int MAX_CACHE_ENTRIES = 512;
     private static final int MAX_COMBINATIONS = 256;
     private static final Map<String, List<String>> CACHE = new LinkedHashMap<>(64, 0.75F, true) {
@@ -30,6 +35,8 @@ public class PinYinSearchUtils {
             return this.size() > MAX_CACHE_ENTRIES;
         }
     };
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
     static {
         // 静态初始化：配置拼音输出格式（小写、无声调、v代替ü）
@@ -49,10 +56,13 @@ public class PinYinSearchUtils {
         if (str == null || str.isEmpty()) {
             return new ArrayList<>();
         }
+<<<<<<< HEAD
         List<String> cached = CACHE.get(str);
         if (cached != null) {
             return new ArrayList<>(cached);
         }
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
         char[] chars = str.toCharArray();
         // 改用方法内局部变量存储每个字符的拼音数组，移除静态变量
@@ -70,7 +80,11 @@ public class PinYinSearchUtils {
                         // 生僻字/无法识别的汉字：保留原字符
                         charPinyinList.add(new String[]{String.valueOf(c)});
                     } else {
+<<<<<<< HEAD
                         charPinyinList.add(new LinkedHashSet<>(List.of(pinyinArray)).toArray(new String[0]));
+=======
+                        charPinyinList.add(pinyinArray);
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
                     }
                 }
             }
@@ -80,9 +94,13 @@ public class PinYinSearchUtils {
         }
 
         // 生成全拼+简拼组合
+<<<<<<< HEAD
         ArrayList<String> result = generatePinyinCombinations(charPinyinList);
         CACHE.put(str, List.copyOf(result));
         return result;
+=======
+        return generatePinyinCombinations(charPinyinList);
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 
     /**
@@ -107,6 +125,7 @@ public class PinYinSearchUtils {
      */
     @NotNull
     private static ArrayList<String> generatePinyinCombinations(List<String[]> charPinyinList) {
+<<<<<<< HEAD
         List<String> fullPinyinList = List.of("");
         List<String> shortPinyinList = List.of("");
         for (String[] currentPinyinArray : charPinyinList) {
@@ -134,3 +153,42 @@ public class PinYinSearchUtils {
         return new ArrayList<>(combined);
     }
 }
+=======
+        ArrayList<String> fullPinyinList = new ArrayList<>();   // 全拼组合列表
+        ArrayList<String> shortPinyinList = new ArrayList<>();  // 简拼组合列表
+        // 遍历每个字符的拼音数组，生成组合
+        for (int i = 0; i < charPinyinList.size(); i++) {
+            String[] currentPinyinArray = charPinyinList.get(i);
+            // 临时存储本轮生成的全拼/简拼
+            ArrayList<String> tempFullList = new ArrayList<>();
+            ArrayList<String> tempShortList = new ArrayList<>();
+            for (String pinyin : currentPinyinArray) {
+                if (i == 0) {
+                    // 第一个字符：直接添加
+                    tempFullList.add(pinyin);
+                    tempShortList.add(String.valueOf(pinyin.charAt(0)));
+                } else {
+                    // 非第一个字符：和已有的组合拼接
+                    for (String existingFull : fullPinyinList) {
+                        tempFullList.add(existingFull + pinyin);
+                    }
+                    for (String existingShort : shortPinyinList) {
+                        tempShortList.add(existingShort + pinyin.charAt(0));
+                    }
+                }
+            }
+            // 更新全拼/简拼列表
+            if (i == 0) {
+                fullPinyinList = tempFullList;
+                shortPinyinList = tempShortList;
+            } else {
+                fullPinyinList = tempFullList;
+                shortPinyinList = tempShortList;
+            }
+        }
+        // 合并全拼和简拼
+        fullPinyinList.addAll(shortPinyinList);
+        return fullPinyinList;
+    }
+}
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)

--- a/src/main/java/me/aleksilassila/litematica/printer/utils/minecraft/PlayerUtils.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/utils/minecraft/PlayerUtils.java
@@ -69,9 +69,15 @@ public class PlayerUtils {
         double dz = Math.max(Math.max(blockPosZ - eyePosZ, eyePosZ - (blockPosZ + 1)), 0);
         return dx * dx + dy * dy + dz * dz < distance * distance;
         //#else
+<<<<<<< HEAD
         //$$ double dx = eyePosX - (blockPosX + 0.5);
         //$$ double dy = eyePosY - (blockPosY + 0.5);
         //$$ double dz = eyePosZ - (blockPosZ + 0.5);
+=======
+        //$$ double dx = eyePosX - blockPosX + 0.5;
+        //$$ double dy = eyePosY - blockPosY + 0.5;
+        //$$ double dz = eyePosZ - blockPosZ + 0.5;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
         //$$ return dx * dx + dy * dy + dz * dz <= distance * distance;
         //#endif
     }

--- a/src/main/java/me/aleksilassila/litematica/printer/utils/mods/TakeItOutUtils.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/utils/mods/TakeItOutUtils.java
@@ -1,7 +1,10 @@
 package me.aleksilassila.litematica.printer.utils.mods;
 
 import net.fabricmc.loader.api.FabricLoader;
+<<<<<<< HEAD
 import me.aleksilassila.litematica.printer.Reference;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.NonNullList;
 import me.aleksilassila.litematica.printer.printer.ActionManager;
@@ -29,7 +32,10 @@ public final class TakeItOutUtils {
     private static Item localPendingItem;
     private static long localPendingStartedAtMs;
     private static int localPendingSettleTicks = -1;
+<<<<<<< HEAD
     private static boolean apiFailureLogged;
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
     private TakeItOutUtils() {
     }
@@ -45,8 +51,12 @@ public final class TakeItOutUtils {
         try {
             Field field = Class.forName(CLIENT_CLASS).getField("AUTOTAKEOUT");
             return field.getBoolean(null);
+<<<<<<< HEAD
         } catch (ReflectiveOperationException | LinkageError exception) {
             logApiFailure("读取自动取货配置", exception);
+=======
+        } catch (ReflectiveOperationException | LinkageError ignored) {
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             return false;
         }
     }
@@ -89,6 +99,7 @@ public final class TakeItOutUtils {
     private static boolean tryRequestFromWorldContainers(ItemStack required) {
         try {
             Class<?> sourcesClass = Class.forName(SOURCES_CLASS);
+<<<<<<< HEAD
             Method requestStack;
             Object result;
             try {
@@ -109,16 +120,30 @@ public final class TakeItOutUtils {
                 );
                 result = requestStack.invoke(null, client, singleStack(required), isSingleItemMode());
             }
+=======
+            Method requestStack = sourcesClass.getMethod(
+                    "requestStack",
+                    Minecraft.class,
+                    ItemStack.class,
+                    boolean.class,
+                    boolean.class
+            );
+            Object result = requestStack.invoke(null, client, singleStack(required), isSingleItemMode(), false);
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             if (Boolean.TRUE.equals(result)) {
                 beginLocalPending(required.getItem());
                 return true;
             }
             return false;
+<<<<<<< HEAD
         } catch (ClassNotFoundException | NoSuchMethodException ignored) {
             // 旧版 Take It Out 只有背包潜影盒取货，没有世界容器 API。
             return false;
         } catch (ReflectiveOperationException | LinkageError exception) {
             logApiFailure("请求世界容器", exception);
+=======
+        } catch (ReflectiveOperationException | LinkageError ignored) {
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             return false;
         }
     }
@@ -146,7 +171,12 @@ public final class TakeItOutUtils {
     private static boolean sendShulkerRequest(int innerSlot, int shulkerSlot, ItemStack required) {
         try {
             Class<?> payloadClass = Class.forName(SHULKER_PAYLOAD_CLASS);
+<<<<<<< HEAD
             Object payload = createShulkerPayload(payloadClass, innerSlot, shulkerSlot);
+=======
+            Constructor<?> constructor = payloadClass.getConstructor(int.class, int.class, boolean.class);
+            Object payload = constructor.newInstance(innerSlot, shulkerSlot, isSingleItemMode());
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             if (!canSend(payloadClass)) {
                 return false;
             }
@@ -154,13 +184,18 @@ public final class TakeItOutUtils {
             sendPayload(payload);
             beginLocalPending(required.getItem());
             return true;
+<<<<<<< HEAD
         } catch (ReflectiveOperationException | LinkageError exception) {
             logApiFailure("请求背包潜影盒", exception);
+=======
+        } catch (ReflectiveOperationException | LinkageError ignored) {
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             clearAwaitingStackIfSameItem(required);
             return false;
         }
     }
 
+<<<<<<< HEAD
     private static Object createShulkerPayload(
             Class<?> payloadClass,
             int innerSlot,
@@ -179,6 +214,8 @@ public final class TakeItOutUtils {
         }
     }
 
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     private static boolean canSend(Class<?> payloadClass) {
         try {
             Field idField = payloadClass.getField("ID");
@@ -194,11 +231,18 @@ public final class TakeItOutUtils {
                 Object result = method.invoke(null, id);
                 return Boolean.TRUE.equals(result);
             }
+<<<<<<< HEAD
         } catch (ReflectiveOperationException | LinkageError exception) {
             logApiFailure("检查网络通道", exception);
             return false;
         }
         return false;
+=======
+        } catch (ReflectiveOperationException | LinkageError ignored) {
+            return true;
+        }
+        return true;
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
     }
 
     private static void beginLocalPending(Item item) {
@@ -274,11 +318,15 @@ public final class TakeItOutUtils {
         try {
             Field field = Class.forName(CLIENT_CLASS).getField("TAKE_SINGLE_ITEM_MODE");
             return field.getBoolean(null);
+<<<<<<< HEAD
         } catch (NoSuchFieldException ignored) {
             // 旧版 payload 不支持单物品模式。
             return false;
         } catch (ReflectiveOperationException | LinkageError exception) {
             logApiFailure("读取单物品模式", exception);
+=======
+        } catch (ReflectiveOperationException | LinkageError ignored) {
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             return false;
         }
     }
@@ -290,8 +338,12 @@ public final class TakeItOutUtils {
         try {
             Object value = Class.forName(CLIENT_CLASS).getField("awaitingStack").get(null);
             return value instanceof ItemStack stack ? stack : ItemStack.EMPTY;
+<<<<<<< HEAD
         } catch (ReflectiveOperationException | LinkageError exception) {
             logApiFailure("读取等待物品", exception);
+=======
+        } catch (ReflectiveOperationException | LinkageError ignored) {
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
             return ItemStack.EMPTY;
         }
     }
@@ -334,6 +386,7 @@ public final class TakeItOutUtils {
         copy.setCount(1);
         return copy;
     }
+<<<<<<< HEAD
 
     private static void logApiFailure(String operation, Throwable exception) {
         if (apiFailureLogged) {
@@ -342,4 +395,6 @@ public final class TakeItOutUtils {
         apiFailureLogged = true;
         Reference.LOGGER.warn("Take It Out API 调用异常，{}失败；已跳过该取货路径", operation, exception);
     }
+=======
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 }

--- a/src/main/resources/assets/litematica-printer/lang/en_us.json
+++ b/src/main/resources/assets/litematica-printer/lang/en_us.json
@@ -120,6 +120,11 @@
   "litematica-printer.config.placeBlocksPerTick.desc": "Number of blocks that can be placed per game tick. Higher values mean more blocks placed each time.\nSet to §b0§r for no limit.",
   "litematica-printer.config.placeCooldown": "Placement Cooldown Time",
   "litematica-printer.config.placeCooldown.desc": "Cooldown time after placing blocks at the same location (in game ticks). Retry placement operation only after cooldown ends.\n§c§lDo not set to 0 unless necessary, otherwise it will cause placing extra blocks, inability to place correctly and other issues!§r",
+<<<<<<< HEAD
+=======
+  "litematica-printer.config.placeReserveCount": "Reserve Item Count",
+  "litematica-printer.config.placeReserveCount.desc": "Skip placement when the currently selected block type would fall below this minimum amount in inventory. Set to 0 to disable.",
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
   "litematica-printer.config.placeRttAdaptiveInterval": "RTT Adaptive Interval",
   "litematica-printer.config.placeRttAdaptiveInterval.desc": "Automatically raise the placement interval to at least one round-trip (your ping) so a placement is not sent before the server confirms the previous one.\nReduces misplaced/ghost blocks on servers, especially with high latency.\nUses your tab-list ping; has no effect in singleplayer/LAN (ping 0).",
   "litematica-printer.config.placeRttSafetyPercent": "RTT Safety Factor",
@@ -217,7 +222,11 @@
   "litematica-printer.config.selectionType.litematica.selection.abovePlayer": "Projection Selection (Above Player)",
   "litematica-printer.config.selectionType.litematica.selection.belowPlayer": "Projection Selection (Below Player)",
   "litematica-printer.config.storeOrderly": "Orderly Item Storage",
+<<<<<<< HEAD
   "litematica-printer.config.storeOrderly.desc": "When the inventory is full, return items retrieved by Quick Shulker to their original shulker and slot first; if that slot cannot hold them, merge into matching stacks and then use empty slots.",
+=======
+  "litematica-printer.config.storeOrderly.desc": "When inventory is full, try to put items retrieved from quick shulker boxes back to original positions;\nThis function has poor performance in 1.18.2 version (may cause lag), recommended to disable.\nZhao Xianyu's code quality is not very good, this function may not work well.",
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
   "litematica-printer.config.switchPrinterMode": "Switch Mode",
   "litematica-printer.config.switchPrinterMode.desc": "Switch printer's current work mode (printing/mining/bedrock breaking, etc.).",
   "litematica-printer.config.unlockBeaconEffects": "Unlock Beacon Effect Limits",
@@ -236,6 +245,10 @@
   "litematica-printer.menu.settings_button": "Printer Settings",
   "litematica-printer.message.falling_block.no_support": "Block %s has no support below, skipping placement",
   "litematica-printer.message.falling_block.mismatch": "Block %s has mismatched block below, skipping placement",
+<<<<<<< HEAD
+=======
+  "litematica-printer.message.reserve_item.skip": "Keeping at least %s of %s in inventory, skipping placement",
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
   "litematica-printer.message.bedrock.creative_mode": "Cannot use Bedrock Breaking mode in Creative mode!",
   "litematica-printer.message.shulker.mod_not_loaded": "Quick Shulker mod not loaded!",
   "litematica-printer.message.close_all_mode": "All modes have been disabled",

--- a/src/main/resources/assets/litematica-printer/lang/lzh.json
+++ b/src/main/resources/assets/litematica-printer/lang/lzh.json
@@ -116,6 +116,11 @@
   "litematica-printer.config.placeBlocksPerTick.desc": "每遊戲刻可置之石數。值愈高則摹形愈疾。\n設§b0§r則無上限。",
   "litematica-printer.config.placeCooldown": "置石調息刻",
   "litematica-printer.config.placeCooldown.desc": "置同一石後須靜候之刻數，期滿方可再置。\n§c§l非必要勿設零，否則恐致多置、誤置之患！§r",
+<<<<<<< HEAD
+=======
+  "litematica-printer.config.placeReserveCount": "保留物品數量",
+  "litematica-printer.config.placeReserveCount.desc": "當當前所選方塊類型在兜內餘量低於此值時，跳過放置。設為0以禁用。",
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
   "litematica-printer.config.placeRttAdaptiveInterval": "延遲自調之息",
   "litematica-printer.config.placeRttAdaptiveInterval.desc": "依爾之延遲(ping)，自抬置石之息，使不低於一往返之數，俾未得遠端覆驗前不遽發其次，故能減伺服之下誤置、虛石之患，延遲愈高愈驗。\n取玩家列之 ping 值；獨機、區網(ping 為零)則不施。",
   "litematica-printer.config.placeRttSafetyPercent": "延遲安穩之率",
@@ -211,7 +216,11 @@
   "litematica-printer.config.selectionType.litematica.selection.abovePlayer": "投影選界（玩家之上）",
   "litematica-printer.config.selectionType.litematica.selection.belowPlayer": "投影選界（玩家之下）",
   "litematica-printer.config.storeOrderly": "物歸其位",
+<<<<<<< HEAD
   "litematica-printer.config.storeOrderly.desc": "囊滿時，先將速啟盒所取之物歸原盒原格；若原格不能盡納，則次合於同物之疊，復用空格。",
+=======
+  "litematica-printer.config.storeOrderly.desc": "囊滿時，試將自遠器/速啟盒取出之物歸返原位；於一·一八·二中此功能效遜（或致遲），建議閉之。宅閒魚之碼質未臻上乘，此功能或難順用。",
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
   "litematica-printer.config.switchPrinterMode": "切式",
   "litematica-printer.config.switchPrinterMode.desc": "切機巧當前之工式（摹形/採掘/破基巖等）。",
   "litematica-printer.config.unlockBeaconEffects": "解信標效限",
@@ -230,6 +239,10 @@
   "litematica-printer.menu.settings_button": "機巧設令",
   "litematica-printer.message.falling_block.no_support": "磚 %s 下方無托，棄置",
   "litematica-printer.message.falling_block.mismatch": "磚 %s 下方石不符，棄置",
+<<<<<<< HEAD
+=======
+  "litematica-printer.message.reserve_item.skip": "保留至少 %s 個 %s 于兜內，棄置",
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
   "litematica-printer.message.bedrock.creative_mode": "創造之態，不可破基巖！",
   "litematica-printer.message.shulker.mod_not_loaded": "速取潛影盒之術未修！",
   "litematica-printer.message.close_all_mode": "已偃息諸態",

--- a/src/main/resources/assets/litematica-printer/lang/zh_cn.json
+++ b/src/main/resources/assets/litematica-printer/lang/zh_cn.json
@@ -120,6 +120,11 @@
   "litematica-printer.config.placeBlocksPerTick.desc": "每游戏刻可放置的方块数量。数值越高，每次打印的方块数越多。\n设为§b0§r时无上限。",
   "litematica-printer.config.placeCooldown": "放置冷却时间",
   "litematica-printer.config.placeCooldown.desc": "同一位置放置方块后的冷却时间(单位为游戏刻)，冷却结束后才会重试放置操作。\n§c§l非必要请勿设置为0，否则会导致多放方块、无法正确放置等问题！§r",
+<<<<<<< HEAD
+=======
+  "litematica-printer.config.placeReserveCount": "保留物品数量",
+  "litematica-printer.config.placeReserveCount.desc": "当当前所选方块类型在背包中的剩余数量低于该值时跳过放置。设为0以禁用。",
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
   "litematica-printer.config.placeRttAdaptiveInterval": "RTT 自适应间隔",
   "litematica-printer.config.placeRttAdaptiveInterval.desc": "根据你的延迟(ping)自动把放置间隔抬高到不低于一次往返，避免在服务端确认上一次放置之前就发出下一个，从而减少服务器下的放错/幽灵方块，高延迟时尤其有效。\n使用玩家列表的 ping 值；单机/局域网(ping 为 0)时不生效。",
   "litematica-printer.config.placeRttSafetyPercent": "RTT 安全系数",
@@ -217,7 +222,11 @@
   "litematica-printer.config.selectionType.litematica.selection.abovePlayer": "投影选区(玩家之上)",
   "litematica-printer.config.selectionType.litematica.selection.belowPlayer": "投影选区(玩家之下)",
   "litematica-printer.config.storeOrderly": "物品有序存放",
+<<<<<<< HEAD
   "litematica-printer.config.storeOrderly.desc": "背包满时，优先将快捷潜影盒取出的物品放回原潜影盒的原槽；原槽无法容纳时，会依次使用同类堆叠和空槽。",
+=======
+  "litematica-printer.config.storeOrderly.desc": "背包满时，尝试将从快捷潜影盒取出的物品放回原位置；\n1.18.2版本中此功能性能较差(可能导致卡顿)，建议关闭。\n宅闲鱼的代码质量并不是很好，这个功能可能不太好用。",
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
   "litematica-printer.config.switchPrinterMode": "切换模式",
   "litematica-printer.config.switchPrinterMode.desc": "切换打印机的当前工作模式(打印/挖掘/破基岩等)。",
   "litematica-printer.config.unlockBeaconEffects": "解锁信标效果限制",
@@ -236,6 +245,10 @@
   "litematica-printer.menu.settings_button": "打印机设置",
   "litematica-printer.message.falling_block.no_support": "方块 %s 下方无支撑，跳过放置",
   "litematica-printer.message.falling_block.mismatch": "方块 %s 下方方块不相符，跳过放置",
+<<<<<<< HEAD
+=======
+  "litematica-printer.message.reserve_item.skip": "保留至少 %s 个 %s 于背包，跳过放置",
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
   "litematica-printer.message.bedrock.creative_mode": "创造模式无法使用破基岩模式！",
   "litematica-printer.message.shulker.mod_not_loaded": "快捷潜影盒模组未加载！",
   "litematica-printer.message.close_all_mode": "已关闭全部模式",

--- a/src/main/resources/assets/litematica-printer/lang/zh_tw.json
+++ b/src/main/resources/assets/litematica-printer/lang/zh_tw.json
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 {
+=======
+﻿{
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
   "litematica-printer.auto_disable_notice": "印表機已自動關閉",
   "litematica-printer.config.bedrock": "破基岩",
   "litematica-printer.config.bedrock.desc": "調用BedrockMiner模組實現基岩挖掘，未安裝該模組則此功能不可用。",
@@ -116,6 +120,11 @@
   "litematica-printer.config.placeBlocksPerTick.desc": "每遊戲刻可放置的方塊數量。數值越高，每次列印的方塊數越多。\n設為§b0§r時無上限。",
   "litematica-printer.config.placeCooldown": "放置冷卻時間",
   "litematica-printer.config.placeCooldown.desc": "同一位置放置方塊後的冷卻時間(單位為遊戲刻)，冷卻結束後才會重試放置操作。\n§c§l非必要請勿設定為0，否則會導致多放方塊、無法正確放置等問題！§r",
+<<<<<<< HEAD
+=======
+  "litematica-printer.config.placeReserveCount": "保留物品數量",
+  "litematica-printer.config.placeReserveCount.desc": "當當前所選方塊類型在背包中的剩餘數量低於該值時跳過放置。設為0以禁用。",
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
   "litematica-printer.config.placeRttAdaptiveInterval": "RTT 自適應間隔",
   "litematica-printer.config.placeRttAdaptiveInterval.desc": "根據你的延遲(ping)自動把放置間隔抬高到不低於一次往返，避免在伺服端確認上一次放置之前就發出下一個，從而減少伺服器下的放錯/幽靈方塊，高延遲時尤其有效。\n使用玩家列表的 ping 值；單機/區域網路(ping 為 0)時不生效。",
   "litematica-printer.config.placeRttSafetyPercent": "RTT 安全係數",
@@ -211,7 +220,11 @@
   "litematica-printer.config.selectionType.litematica.selection.abovePlayer": "投影選區(玩家之上)",
   "litematica-printer.config.selectionType.litematica.selection.belowPlayer": "投影選區(玩家之下)",
   "litematica-printer.config.storeOrderly": "物品有序存放",
+<<<<<<< HEAD
   "litematica-printer.config.storeOrderly.desc": "背包滿時，優先將快捷潛影盒取出的物品放回原潛影盒的原槽；原槽無法容納時，會依次使用同類堆疊和空槽。",
+=======
+  "litematica-printer.config.storeOrderly.desc": "背包滿時，嘗試將從快捷界伏盒取出的物品放回原位置；\n1.18.2版本中此功能性能較差(可能導致卡頓)，建議關閉。\n宅閒魚的程式碼品質並不是很好，這個功能可能不太好用。",
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
   "litematica-printer.config.switchPrinterMode": "切換模式",
   "litematica-printer.config.switchPrinterMode.desc": "切換印表機的當前工作模式(列印/挖掘/破基岩等)。",
   "litematica-printer.config.unlockBeaconEffects": "解除信標效果限制",
@@ -230,6 +243,10 @@
   "litematica-printer.menu.settings_button": "印表機設定",
   "litematica-printer.message.falling_block.no_support": "方塊 %s 下方無支撐，跳過放置",
   "litematica-printer.message.falling_block.mismatch": "方塊 %s 下方方塊不相符，跳過放置",
+<<<<<<< HEAD
+=======
+  "litematica-printer.message.reserve_item.skip": "保留至少 %s 個 %s 於背包，跳過放置",
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)
   "litematica-printer.message.bedrock.creative_mode": "創造模式無法使用破基岩模式！",
   "litematica-printer.message.shulker.mod_not_loaded": "快捷潛影盒模組未載入！",
   "litematica-printer.message.close_all_mode": "已關閉全部模式",
@@ -257,3 +274,7 @@
   "litematica-printer.config.printBonemealCropsClicks": "農作物催熟連點次數",
   "litematica-printer.config.printBonemealCropsClicks.desc": "每次處理作物時連續使用骨粉的次數。\n數值越高，催熟越快，但骨粉消耗也會更猛。"
 }
+<<<<<<< HEAD
+=======
+
+>>>>>>> 766717f4 (feat: Add inventory reserve feature for block placement)

--- a/versions/1.21.1/gradle.properties
+++ b/versions/1.21.1/gradle.properties
@@ -11,11 +11,16 @@ fabric_version=0.116.8+1.21.1
 # https://jitpack.io/#sakura-ryoko/tweakeroo
 # https://jitpack.io/#sakura-ryoko/litematica
 malilib=0.21.10
+<<<<<<< HEAD
 litematica=0.19.61
 tweakeroo=0.21.61
 malilib_artifact=malilib-fabric-1.21
 litematica_artifact=litematica-fabric-1.21
 tweakeroo_artifact=tweakeroo-fabric-1.21
+=======
+litematica=0.19.60
+tweakeroo=0.21.61
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
 # https://modrinth.com/mod/modmenu/versions
 modmenu=11.0.3

--- a/versions/1.21.11/gradle.properties
+++ b/versions/1.21.11/gradle.properties
@@ -11,12 +11,18 @@ fabric_version=0.140.2+1.21.11
 # https://jitpack.io/#sakura-ryoko/malilib
 # https://jitpack.io/#sakura-ryoko/tweakeroo
 # https://jitpack.io/#sakura-ryoko/litematica
+<<<<<<< HEAD
 malilib=0.27.14
 litematica=0.26.11
 tweakeroo=0.27.4
 malilib_artifact=malilib-fabric-1.21.11
 litematica_artifact=litematica-fabric-1.21.11
 tweakeroo_artifact=tweakeroo-fabric-1.21.11
+=======
+malilib=0.27.5
+litematica=0.25.4
+tweakeroo=0.27.4
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
 quickshulker=https://github.com/MoRanpcy/quickshulker/releases/download/2.10.0-1.21.11/quickshulker-2.10.0-1.21.11.jar
 

--- a/versions/1.21.3/gradle.properties
+++ b/versions/1.21.3/gradle.properties
@@ -11,11 +11,16 @@ fabric_version=0.106.1+1.21.3
 # https://jitpack.io/#sakura-ryoko/tweakeroo
 # https://jitpack.io/#sakura-ryoko/litematica
 malilib=0.22.8
+<<<<<<< HEAD
 litematica=0.20.9
 tweakeroo=0.22.8
 malilib_artifact=malilib-fabric-1.21.3
 litematica_artifact=litematica-fabric-1.21.3
 tweakeroo_artifact=tweakeroo-fabric-1.21.3
+=======
+litematica=0.20.8
+tweakeroo=0.22.8
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
 # https://modrinth.com/mod/modmenu/versions
 modmenu=12.0.0

--- a/versions/1.21.4/gradle.properties
+++ b/versions/1.21.4/gradle.properties
@@ -11,11 +11,16 @@ fabric_version=0.115.0+1.21.4
 # https://jitpack.io/#sakura-ryoko/tweakeroo
 # https://jitpack.io/#sakura-ryoko/litematica
 malilib=0.23.5
+<<<<<<< HEAD
 litematica=0.21.7
 tweakeroo=0.23.6
 malilib_artifact=malilib-fabric-1.21.4
 litematica_artifact=litematica-fabric-1.21.4
 tweakeroo_artifact=tweakeroo-fabric-1.21.4
+=======
+litematica=0.21.6
+tweakeroo=0.23.6
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
 # https://modrinth.com/mod/modmenu/versions
 modmenu=13.0.1

--- a/versions/1.21.5/gradle.properties
+++ b/versions/1.21.5/gradle.properties
@@ -11,11 +11,16 @@ fabric_version=0.121.0+1.21.5
 # https://jitpack.io/#sakura-ryoko/tweakeroo
 # https://jitpack.io/#sakura-ryoko/litematica
 malilib=0.24.3
+<<<<<<< HEAD
 litematica=0.22.5
 tweakeroo=0.24.3
 malilib_artifact=malilib-fabric-1.21.5
 litematica_artifact=litematica-fabric-1.21.5
 tweakeroo_artifact=tweakeroo-fabric-1.21.5
+=======
+litematica=0.22.4
+tweakeroo=0.24.3
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
 # https://modrinth.com/mod/modmenu/versions
 modmenu=14.0.1

--- a/versions/1.21.6/gradle.properties
+++ b/versions/1.21.6/gradle.properties
@@ -12,11 +12,16 @@ fabric_version=0.128.1+1.21.6
 # https://jitpack.io/#sakura-ryoko/tweakeroo
 # https://jitpack.io/#sakura-ryoko/litematica
 malilib=0.25.7
+<<<<<<< HEAD
 litematica=0.23.7
 tweakeroo=0.25.6
 malilib_artifact=malilib-fabric-1.21.8
 litematica_artifact=litematica-fabric-1.21.8
 tweakeroo_artifact=tweakeroo-fabric-1.21.8
+=======
+litematica=0.23.6
+tweakeroo=0.25.6
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
 # https://modrinth.com/mod/modmenu/versions
 modmenu=15.0.1

--- a/versions/1.21.9/gradle.properties
+++ b/versions/1.21.9/gradle.properties
@@ -11,12 +11,18 @@ fabric_version=0.134.0+1.21.9
 # https://jitpack.io/#sakura-ryoko/malilib
 # https://jitpack.io/#sakura-ryoko/tweakeroo
 # https://jitpack.io/#sakura-ryoko/litematica
+<<<<<<< HEAD
 malilib=0.26.7
 litematica=0.24.8
 tweakeroo=0.26.5
 malilib_artifact=malilib-fabric-1.21.10
 litematica_artifact=litematica-fabric-1.21.10
 tweakeroo_artifact=tweakeroo-fabric-1.21.10
+=======
+malilib=0.26.8
+litematica=0.24.7
+tweakeroo=0.26.5
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
 # https://modrinth.com/mod/modmenu/versions
 modmenu=16.0.0

--- a/versions/26.1/gradle.properties
+++ b/versions/26.1/gradle.properties
@@ -11,12 +11,18 @@ fabric_version=0.144.3+26.1
 # https://jitpack.io/#sakura-ryoko/malilib
 # https://jitpack.io/#sakura-ryoko/tweakeroo
 # https://jitpack.io/#sakura-ryoko/litematica
+<<<<<<< HEAD
 malilib=0.28.8
 litematica=0.27.9
 tweakeroo=0.28.0
 malilib_artifact=malilib-fabric-26.1.2
 litematica_artifact=litematica-fabric-26.1.2
 tweakeroo_artifact=tweakeroo-fabric-26.1
+=======
+malilib=0.28.1
+litematica=0.27.9
+tweakeroo=0.28.0
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
 # https://modrinth.com/mod/modmenu/versions
 # https://maven.terraformersmc.com/releases/com/terraformersmc/modmenu

--- a/versions/26.2/gradle.properties
+++ b/versions/26.2/gradle.properties
@@ -11,12 +11,18 @@ loader_version=0.19.3
 # https://jitpack.io/#sakura-ryoko/malilib
 # https://jitpack.io/#sakura-ryoko/tweakeroo
 # https://jitpack.io/#sakura-ryoko/litematica
+<<<<<<< HEAD
 malilib=0.29.2
 litematica=0.28.3
 tweakeroo=0.29.0
 malilib_artifact=malilib-fabric-26.2
 litematica_artifact=litematica-fabric-26.2
 tweakeroo_artifact=tweakeroo-fabric-26.2
+=======
+malilib=0.29.0
+litematica=0.28.4
+tweakeroo=0.29.0
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 
 # https://modrinth.com/mod/modmenu/versions
 # https://maven.terraformersmc.com/releases/com/terraformersmc/modmenu

--- a/versions/mapping-1.21.10-1.21.11.txt
+++ b/versions/mapping-1.21.10-1.21.11.txt
@@ -1,3 +1,7 @@
+<<<<<<< HEAD
 net.minecraft.resources.ResourceLocation net.minecraft.resources.Identifier
 
 fi.dy.masa.malilib.util.JsonUtils fi.dy.masa.malilib.util.data.json.JsonUtils
+=======
+net.minecraft.resources.ResourceLocation net.minecraft.resources.Identifier
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)

--- a/versions/mapping-1.21.11-26.1.txt
+++ b/versions/mapping-1.21.11-26.1.txt
@@ -7,6 +7,11 @@ net.minecraft.client.multiplayer.MultiPlayerGameMode handleInventoryMouseClick()
 net.minecraft.client.gui.GuiGraphics net.minecraft.client.gui.GuiGraphicsExtractor
 net.minecraft.client.gui.GuiGraphicsExtractor drawString() text()
 
+<<<<<<< HEAD
+=======
+fi.dy.masa.malilib.util.JsonUtils fi.dy.masa.malilib.util.data.json.JsonUtils
+
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)
 net.minecraft.world.level.block.FarmBlock net.minecraft.world.level.block.FarmlandBlock
 net.minecraft.world.level.block.WaterlilyBlock net.minecraft.world.level.block.LilyPadBlock
 
@@ -14,4 +19,8 @@ net.minecraft.world.inventory.ClickType net.minecraft.world.inventory.ContainerI
 net.minecraft.world.item.ItemStack getItemHolder() typeHolder()
 net.minecraft.world.level.ChunkPos asLong() pack()
 
+<<<<<<< HEAD
 net.minecraft.core.TypedInstance getTags() tags()
+=======
+net.minecraft.core.TypedInstance getTags() tags()
+>>>>>>> 98e8cb2f (feat: Initial commit - Add upstream litematica-printer repository)


### PR DESCRIPTION
- 新增 PLACE_RESERVE_COUNT 配置選項（預設值：0為停用）
- 放置前檢查物品數量，低於閾值則跳過
- 為疊加訊息添加 5 秒冷卻時間
- 增加對應多國語言翻譯（en_us、zh_cn、zh_tw、lzh）
- 修正繁體中文翻譯：于背包 → 於背包

---

想為 printer 加上這個功能的原因是，我自己有一個可以使用地毯複製的
可以重複使用的地圖畫生產機，我坐在礦車中使用 printer 掛機的時候
並不希望把方塊全部放光，這樣水道來的地毯會因為身上塞滿了垃圾而無法被補充

我認為這個功能還可以用來掛機樹場、或是紫頌果農場的情況
身上永遠有最後一個物品會是很方便的防呆、防壞機制

使用 Copilot Agent 完成的修改，在 26.2 進行過簡單的生存模式測試
希望可以考慮在原始版本加上這個功能